### PR TITLE
Rename Control Planes

### DIFF
--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for deploying Unikorn Core
 
 type: application
 
-version: v0.1.8
-appVersion: v0.1.8
+version: v0.1.9
+appVersion: v0.1.9
 
 icon: https://assets.unikorn-cloud.org/images/logos/dark-on-light/icon.svg

--- a/pkg/apis/unikorn/v1alpha1/helpers.go
+++ b/pkg/apis/unikorn/v1alpha1/helpers.go
@@ -62,7 +62,7 @@ func GetCondition(conditions []Condition, t ConditionType) (*Condition, error) {
 	return nil, ErrStatusConditionLookup
 }
 
-// UpdateCondition either adds or updates a condition in the control plane
+// UpdateCondition either adds or updates a condition in the resource
 // status. If the condition, status and message match an existing condition
 // the update is ignored.
 func UpdateCondition(conditions *[]Condition, t ConditionType, status corev1.ConditionStatus, reason ConditionReason, message string) {

--- a/pkg/apis/unikorn/v1alpha1/interfaces.go
+++ b/pkg/apis/unikorn/v1alpha1/interfaces.go
@@ -52,7 +52,7 @@ type StatusConditionReader interface {
 
 // StatusConditionWriter allows generic status conditions to be updated.
 type StatusConditionWriter interface {
-	// StatusConditionWrite either adds or updates a condition in the control plane
+	// StatusConditionWrite either adds or updates a condition in the resource
 	// status. If the condition, status and message match an existing condition
 	// the update is ignored.
 	StatusConditionWrite(t ConditionType, status corev1.ConditionStatus, reason ConditionReason, message string)

--- a/pkg/cd/argocd/driver.go
+++ b/pkg/cd/argocd/driver.go
@@ -271,7 +271,7 @@ func (d *Driver) CreateOrUpdateHelmApplication(ctx context.Context, id *cd.Resou
 
 	// Bit of a hack, for clusters, we know they are working and gated on
 	// remote cluster creation, so can allow the rest to provision while it's
-	// still sorting its control plane out.
+	// still sorting its manager out.
 	if app.AllowDegraded && resource.Status.Health.Status == argoprojv1.Degraded {
 		return nil
 	}

--- a/pkg/cd/types.go
+++ b/pkg/cd/types.go
@@ -106,7 +106,7 @@ type HelmApplication struct {
 
 	// Cluster identifies the cluster to install on to.
 	// By definition we require the CD provider to support multiple
-	// clusters to support control plane virtual clusters, and the
+	// clusters to support cluster manager lane virtual clusters, and the
 	// CAPI Kubernetes clusters we create.
 	Cluster *ResourceIdentifier
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -61,7 +61,7 @@ const (
 	VersionLabel = "unikorn.unikorn-cloud.org/version"
 
 	// KindLabel is used to match a resource that may be owned by a particular kind.
-	// For example, projects and control planes are modelled on namespaces.  For CPs
+	// For example, projects and cluster managers are modelled on namespaces.  For CPs
 	// you have to select based on project and CP name, because of name reuse, but
 	// this raises the problem that selecting a project's namespace will match multiple
 	// so this provides a concrete type associated with each resource.
@@ -73,8 +73,8 @@ const (
 	// KindLabelValueProject is used to denote a resource belongs to this type.
 	KindLabelValueProject = "project"
 
-	// KindLabelValueControlPlane is used to denote a resource belongs to this type.
-	KindLabelValueControlPlane = "controlplane"
+	// KindLabelValueClusterManager is used to denote a resource belongs to this type.
+	KindLabelValueClusterManager = "clustermanager"
 
 	// KindLabelValueKubernetesCluster is used to denote a resource belongs to this type.
 	KindLabelValueKubernetesCluster = "kubernetescluster"
@@ -87,9 +87,9 @@ const (
 	// control of this tool.  Useful for label selection.
 	ProjectLabel = "unikorn.unikorn-cloud.org/project"
 
-	// ControlPlaneLabel is a label applied to resources to indicate is belongs
-	// to a specific control plane.
-	ControlPlaneLabel = "unikorn.unikorn-cloud.org/controlplane"
+	// ClusterManagerLabel is a label applied to resources to indicate is belongs
+	// to a specific cluster manager.
+	ClusterManagerLabel = "unikorn.unikorn-cloud.org/clustermanager"
 
 	// KubernetesClusterLabel is applied to resources to indicate it belongs
 	// to a specific cluster.
@@ -122,15 +122,15 @@ const (
 
 // LabelPriorities assigns a priority to the labels for sorting.  Most things
 // use the labels to uniquely identify a resource.  For example, when we create
-// a remote cluster in ArgoCD we use a tuple of project, control plane and optionally
-// the cluster.  This gives a unique identifier given projects and control planes
+// a remote cluster in ArgoCD we use a tuple of project, cluster manager and optionally
+// the cluster.  This gives a unique identifier given projects and cluster managers
 // provide a namespace abstraction, and a deterministic one as the order is defined.
 // This function is required because labels are given as a map, and thus are
 // no-deterministically ordered when iterating in go.
 func LabelPriorities() []string {
 	return []string{
 		KubernetesClusterLabel,
-		ControlPlaneLabel,
+		ClusterManagerLabel,
 		ProjectLabel,
 		OrganizationLabel,
 	}


### PR DESCRIPTION
This is overloaded when discussing Kubernetes, so rename them cluster managers.