### PR TITLE
Make Authorization for Clients use User Info

### DIFF
--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for deploying Unikorn Core
 
 type: application
 
-version: v0.1.11
-appVersion: v0.1.11
+version: v0.1.12
+appVersion: v0.1.12
 
 icon: https://assets.unikorn-cloud.org/images/logos/dark-on-light/icon.svg

--- a/pkg/authorization/accesstoken/context.go
+++ b/pkg/authorization/accesstoken/context.go
@@ -14,20 +14,22 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package roles
+package accesstoken
 
-// Role defines the role a user has within the scope of a group.
-// +kubebuilder:validation:Enum=superAdmin;admin;user;reader
-type Role string
-
-const (
-	// SuperAdmin users can do anything, anywhere, and should be
-	// restricted to platform operators only.
-	SuperAdmin Role = "superAdmin"
-	// Admin users can do anything within an organization.
-	Admin Role = "admin"
-	// Users can do anything within allowed projects.
-	User Role = "user"
-	// Readers have read-only access within allowed projects.
-	Reader Role = "reader"
+import (
+	"context"
 )
+
+type keyType int
+
+//nolint:gochecknoglobals
+var key keyType
+
+func NewContext(ctx context.Context, accessToken string) context.Context {
+	return context.WithValue(ctx, key, accessToken)
+}
+
+func FromContext(ctx context.Context) string {
+	//nolint:forcetypeassert
+	return ctx.Value(key).(string)
+}

--- a/pkg/authorization/userinfo/context.go
+++ b/pkg/authorization/userinfo/context.go
@@ -14,20 +14,24 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package roles
+package userinfo
 
-// Role defines the role a user has within the scope of a group.
-// +kubebuilder:validation:Enum=superAdmin;admin;user;reader
-type Role string
+import (
+	"context"
 
-const (
-	// SuperAdmin users can do anything, anywhere, and should be
-	// restricted to platform operators only.
-	SuperAdmin Role = "superAdmin"
-	// Admin users can do anything within an organization.
-	Admin Role = "admin"
-	// Users can do anything within allowed projects.
-	User Role = "user"
-	// Readers have read-only access within allowed projects.
-	Reader Role = "reader"
+	"github.com/coreos/go-oidc/v3/oidc"
 )
+
+type keyType int
+
+//nolint:gochecknoglobals
+var key keyType
+
+func NewContext(ctx context.Context, userinfo *oidc.UserInfo) context.Context {
+	return context.WithValue(ctx, key, userinfo)
+}
+
+func FromContext(ctx context.Context) *oidc.UserInfo {
+	//nolint:forcetypeassert
+	return ctx.Value(key).(*oidc.UserInfo)
+}

--- a/pkg/server/middleware/openapi/interfaces.go
+++ b/pkg/server/middleware/openapi/interfaces.go
@@ -17,19 +17,13 @@ limitations under the License.
 package openapi
 
 import (
+	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/getkin/kin-openapi/openapi3filter"
 )
 
-// AuthorizationContext is passed through the middleware to propagate
-// information back to the top level handler.
-type AuthorizationContext struct {
-	// Error allows us to return a verbose error, unwrapped by whatever
-	// the openapi validaiton is doing.
-	Error error
-}
-
 // Authorizer allows authorizers to be plugged in interchangeably.
 type Authorizer interface {
-	// Authorize checks the request against the OpenAPI security scheme.
-	Authorize(authentication *openapi3filter.AuthenticationInput) error
+	// Authorize checks the request against the OpenAPI security scheme
+	// and returns the access token.
+	Authorize(authentication *openapi3filter.AuthenticationInput) (string, *oidc.UserInfo, error)
 }


### PR DESCRIPTION
Access tokens are opaque, so we call back to the identity service to validate them, otherwise we'd need to worry about key distribution etc. This also gives us a handy point to return all the necessary RBAC info.