### PR TITLE
Improve RBAC

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -6,7 +6,7 @@ on:
     tags-ignore:
     - '*'
 env:
-  GO_VERSION: 1.21.1
+  GO_VERSION: 1.22.1
 jobs:
   Coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -6,7 +6,7 @@ on:
     tags-ignore:
     - '*'
 env:
-  GO_VERSION: 1.21.1
+  GO_VERSION: 1.22.1
 jobs:
   Static:
     runs-on: ubuntu-latest

--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for deploying Unikorn Core
 
 type: application
 
-version: v0.1.15
-appVersion: v0.1.15
+version: v0.1.16
+appVersion: v0.1.16
 
 icon: https://assets.unikorn-cloud.org/images/logos/dark-on-light/icon.svg

--- a/pkg/authorization/rbac/interfaces.go
+++ b/pkg/authorization/rbac/interfaces.go
@@ -22,10 +22,6 @@ import (
 
 // Authorizer defines an interface for authorization.
 type Authorizer interface {
-	// AllowedByRole allows access based on role, typically used for admin only interfaces.
-	AllowedByRole(role roles.Role) error
-	// AllowedByGroup allows access based on groups assigned to a restricted resource.
-	AllowedByGroup(groupIDs []string) error
-	// AllowedByGroupRole allows access baseed on groups and the role, typically for write access.
-	AllowedByGroupRole(groupIDs []string, role roles.Role) error
+	// Allow allows access based on API scope and required permissions.
+	Allow(scope string, permission roles.Permission) error
 }

--- a/pkg/authorization/rbac/types.go
+++ b/pkg/authorization/rbac/types.go
@@ -30,8 +30,6 @@ type GroupPermissions struct {
 
 // OrganizationPermissions are privilege grants for an organization.
 type OrganizationPermissions struct {
-	// IsAdmin allows the user to play with all resources in an organization.
-	IsAdmin bool `json:"isAdmin,omitempty"`
 	// Name is the name of the organization.
 	Name string `json:"name"`
 	// Groups are any groups the user belongs to in an organization.

--- a/pkg/authorization/roles/roles.go
+++ b/pkg/authorization/roles/roles.go
@@ -16,7 +16,16 @@ limitations under the License.
 
 package roles
 
-// Role defines the role a user has within the scope of a group.
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	ErrRoleNotFound = errors.New("requested role not found")
+)
+
+// Role defines the role a user has within the Scope of a group.
 // +kubebuilder:validation:Enum=superAdmin;admin;user;reader
 type Role string
 
@@ -31,3 +40,109 @@ const (
 	// Readers have read-only access within allowed projects.
 	Reader Role = "reader"
 )
+
+type Permission string
+
+const (
+	Create Permission = "create"
+	Read   Permission = "read"
+	Update Permission = "update"
+	Delete Permission = "delete"
+)
+
+type Permissions []Permission
+
+type ScopedPermissionsMap map[string]Permissions
+
+type RoleInfo struct {
+	// Permissions defined what the role can do.
+	Permissions ScopedPermissionsMap
+}
+
+type RoleManager struct {
+	// mapper provides a quick lookup of role.
+	mapper map[Role]*RoleInfo
+}
+
+func New() *RoleManager {
+	reader := &RoleInfo{
+		Permissions: ScopedPermissionsMap{
+			"organization": Permissions{
+				Read,
+			},
+			"project": Permissions{
+				Read,
+			},
+			"infrastructure": Permissions{
+				Read,
+			},
+		},
+	}
+
+	user := &RoleInfo{
+		Permissions: ScopedPermissionsMap{
+			"organization": Permissions{
+				Read,
+			},
+			"project": Permissions{
+				Read,
+			},
+			"infrastructure": Permissions{
+				Create,
+				Read,
+				Update,
+				Delete,
+			},
+		},
+	}
+
+	// admin can do most things in an organization, except create and
+	// delete them as creation will require a separate verification and billing
+	// flow, deletion is too damned dangerous.
+	admin := &RoleInfo{
+		Permissions: ScopedPermissionsMap{
+			"organization": Permissions{
+				Read,
+				Update,
+			},
+			"oauth2provider:public": Permissions{
+				Read,
+			},
+			"oauth2provider:private": Permissions{
+				Create,
+				Read,
+				Update,
+				Delete,
+			},
+			"project": Permissions{
+				Create,
+				Read,
+				Update,
+				Delete,
+			},
+			"infrastructure": Permissions{
+				Create,
+				Read,
+				Update,
+				Delete,
+			},
+		},
+	}
+
+	return &RoleManager{
+		mapper: map[Role]*RoleInfo{
+			Reader: reader,
+			User:   user,
+			Admin:  admin,
+		},
+	}
+}
+
+func (m *RoleManager) GetRole(role Role) (*RoleInfo, error) {
+	roleInfo, ok := m.mapper[role]
+	if !ok {
+		return nil, fmt.Errorf("%w: %v", ErrRoleNotFound, role)
+	}
+
+	return roleInfo, nil
+}

--- a/pkg/authorization/userinfo/rbac.go
+++ b/pkg/authorization/userinfo/rbac.go
@@ -25,5 +25,5 @@ import (
 func NewAuthorizer(ctx context.Context, organization string) (rbac.Authorizer, error) {
 	userinfo := FromContext(ctx)
 
-	return rbac.NewAuthorizer(userinfo.RBAC, organization)
+	return rbac.New(userinfo.RBAC, organization)
 }


### PR DESCRIPTION
Add a clear set of permissions that are granted to each role.  This allows fine-grain control at a per-aendpoint level.