### PR TITLE
Add User Project Scoping

### DIFF
--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for deploying Unikorn Core
 
 type: application
 
-version: v0.1.21
-appVersion: v0.1.21
+version: v0.1.22
+appVersion: v0.1.22
 
 icon: https://assets.unikorn-cloud.org/images/logos/dark-on-light/icon.svg

--- a/pkg/authorization/rbac/types.go
+++ b/pkg/authorization/rbac/types.go
@@ -28,12 +28,26 @@ type GroupPermissions struct {
 	Roles []string `json:"roles"`
 }
 
+// ProjectPermissions define projects the user hass access to
+// and the roles that granted those permissions.
+type ProjectPermissions struct {
+	// Name is the project name.
+	Name string `json:"name"`
+	// Roles are the privileges a user has within the project.
+	Roles []string `json:"roles"`
+}
+
 // OrganizationPermissions are privilege grants for an organization.
 type OrganizationPermissions struct {
 	// Name is the name of the organization.
 	Name string `json:"name"`
 	// Groups are any groups the user belongs to in an organization.
+	// These define access control lists.
 	Groups []GroupPermissions `json:"groups,omitempty"`
+	// Projects are any projects the user belongs to in an organization
+	// via group inclusion.  These define scoping rules when accessing
+	// resources.
+	Projects []ProjectPermissions `json:"projects,omitempty"`
 }
 
 // Permissions are privilege grants for the entire system.


### PR DESCRIPTION
Organizations and projects are being moved into the identity service as it's intrinsically linked to these via RBAC.  As a result the identity service can resolve scoping rules and return them in the user info for simpler integration of services.