### PR TITLE
Improve Conversion Helpers

### DIFF
--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for deploying Unikorn Core
 
 type: application
 
-version: v0.1.33
-appVersion: v0.1.33
+version: v0.1.34
+appVersion: v0.1.34
 
 icon: https://assets.unikorn-cloud.org/images/logos/dark-on-light/icon.svg


### PR DESCRIPTION
Make the interfaces less flexible, and less prone to errors, and also capable of spitting out better types for client code.