### PR TITLE
Add Region Identity Cleanup Stuff

### DIFF
--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for deploying Unikorn Core
 
 type: application
 
-version: v0.1.45
-appVersion: v0.1.45
+version: v0.1.46
+appVersion: v0.1.46
 
 icon: https://assets.unikorn-cloud.org/images/logos/dark-on-light/icon.svg

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -85,6 +85,14 @@ const (
 	// RegionAnnotation tells you what region something lives in.
 	RegionAnnotation = "unikorn-cloud.org/region"
 
+	// CloudIdentityAnnotation tells you the cloud identity (in the context if
+	// the region controller) that a resource owns.
+	CloudIdentityAnnotation = "unikorn-cloud.org/cloud-identity-id"
+
+	// IdentityCleanupReadyEventReason is used to identift asynchronous clean up
+	// routines.
+	IdentityCleanupReadyEventReason = "IdentityCleanupReady"
+
 	// Finalizer is applied to resources that need to be deleted manually
 	// and do other complex logic.
 	Finalizer = "unikorn"


### PR DESCRIPTION
The kubernetes service needs to remember its identity ID so it can raise an event that is picked up by the region service to delete that identity in a way that's actually possible.