### PR TITLE
Add Shared CA to Chart

### DIFF
--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for deploying Unikorn Core
 
 type: application
 
-version: v0.1.46
-appVersion: v0.1.46
+version: v0.1.47
+appVersion: v0.1.47
 
 icon: https://assets.unikorn-cloud.org/images/logos/dark-on-light/icon.svg

--- a/charts/core/templates/_helpers.tpl
+++ b/charts/core/templates/_helpers.tpl
@@ -1,0 +1,97 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "unikorn.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "unikorn.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "unikorn.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "unikorn.labels" -}}
+helm.sh/chart: {{ include "unikorn.chart" . }}
+{{ include "unikorn.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "unikorn.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "unikorn.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "unikorn.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "unikorn.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the container images
+*/}}
+{{- define "unikorn.defaultRepositoryPath" -}}
+{{- if .Values.repository }}
+{{- printf "%s/%s" .Values.repository .Values.organization }}
+{{- else }}
+{{- .Values.organization }}
+{{- end }}
+{{- end }}
+
+{{- define "unikorn.image" -}}
+{{- .Values.image | default (printf "%s/unikorn-identity:%s" (include "unikorn.defaultRepositoryPath" .) (.Values.tag | default .Chart.Version)) }}
+{{- end }}
+
+{{- define "unikorn.organizationControllerImage" -}}
+{{- .Values.organizationController.image | default (printf "%s/unikorn-organization-controller:%s" (include "unikorn.defaultRepositoryPath" .) (.Values.tag | default .Chart.Version)) }}
+{{- end }}
+
+{{- define "unikorn.projectControllerImage" -}}
+{{- .Values.projectController.image | default (printf "%s/unikorn-project-controller:%s" (include "unikorn.defaultRepositoryPath" .) (.Values.tag | default .Chart.Version)) }}
+{{- end }}
+
+{{/*
+Create image pull secrets
+*/}}
+{{- define "unikorn.imagePullSecrets" -}}
+{{- if .Values.imagePullSecret -}}
+- name: {{ .Values.imagePullSecret }}
+{{ end }}
+{{- if .Values.dockerConfig -}}
+- name: docker-config
+{{- end }}
+{{- end }}

--- a/charts/core/templates/certificate.yaml
+++ b/charts/core/templates/certificate.yaml
@@ -1,0 +1,22 @@
+{{- if (and .Values.ca .Values.ca.enabled .Values.ca.generate) }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: unikorn-ca
+  namespace: {{ .Values.certManager.namespace }}
+  labels:
+    {{- include "unikorn.labels" . | nindent 4 }}
+spec:
+  issuerRef:
+    group: cert-manager.io
+    kind: Issuer
+    name: unikorn-self-signed-issuer
+  privateKey:
+    algorithm: RSA
+    encoding: PKCS8
+    size: 4096
+  secretName: unikorn-ca
+  isCA: true
+  commonName: Unikorn CA
+  duration: 87600h
+{{- end }}

--- a/charts/core/templates/clusterissuer.yaml
+++ b/charts/core/templates/clusterissuer.yaml
@@ -1,0 +1,11 @@
+{{- if (and .Values.ca .Values.ca.enabled) }}
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: unikorn-issuer
+  labels:
+    {{- include "unikorn.labels" . | nindent 4 }}
+spec:
+  ca:
+    secretName: unikorn-ca
+{{- end }}

--- a/charts/core/templates/issuer.yaml
+++ b/charts/core/templates/issuer.yaml
@@ -1,0 +1,11 @@
+{{- if (and .Values.ca .Values.ca.enabled .Values.ca.generate) }}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: unikorn-self-signed-issuer
+  namespace: {{ .Values.certManager.namespace }}
+  labels:
+    {{- include "unikorn.labels" . | nindent 4 }}
+spec:
+  selfSigned: {}
+{{- end }}

--- a/charts/core/templates/secret.yaml
+++ b/charts/core/templates/secret.yaml
@@ -1,0 +1,13 @@
+{{- if (and .Values.ca .Values.ca.enabled (not .Values.ca.generate)) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: unikorn-ca
+  namespace: {{ .Values.certManager.namespace }}
+  labels:
+    {{- include "unikorn.labels" . | nindent 4 }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ .Values.ca.certificate }}
+  tls.key: {{ .Values.ca.privateKey }}
+{{- end }}

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -1,0 +1,23 @@
+# Configuration for cert-manager.
+certManager:
+  # The namespace cert-manager is defined in, this is important as things like
+  # ClusterIssuers can consume a secret, but - oddly - doesn't specify a namespace.
+  # Transpires this defaults to the cert-manager namespace.
+  namespace: cert-manager
+
+# This configures a global CA and issuer for all compomponents.
+# Individual components may opt to use this, or use another issuer e.g. Let's Encrypt
+# for a public deployment.
+ca:
+  # Enable CA and issuer generation.  It's harmless to leave it on as this will
+  # not be trusted by a borwser.
+  enabled: true
+
+  # Generate a self signed CA.
+  generate: true
+
+  # If generate is false, then you must specify a certificate and key, which can be
+  # sourced from mkcert which will automatically install it in the system trust store.
+  # These must be base64 encoded strings.
+  # certificate: SSBhbSBjb21wbGV0ZSBub25zZW5zZS4gIFRoYW5rIHlvdSBmb3IgcmVhZGluZyB0aGlzLiAgR2V0IGEgbGlmZSE= 
+  # privateKey: SSBhbSBjb21wbGV0ZSBub25zZW5zZS4gIFRoYW5rIHlvdSBmb3IgcmVhZGluZyB0aGlzLiAgR2V0IGEgbGlmZSE=


### PR DESCRIPTION
One of the bothersome issues with deploying a development cluster is the issue of CAs.  At present all components have a self-signed issuer, which means you have to import a bunch of CAs into your browser.  This allows the generation of a centralized CA (or the import of one from mkcert for example) so you only have to do this once.  This doesn't address the issue of distributing that CA to other services e.g. kubernetes service calling back into identity for token validation, but it's a step in the right direction.