### PR TITLE
Remove Identity ACL Accessor

### DIFF
--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for deploying Unikorn Core
 
 type: application
 
-version: v0.1.47
-appVersion: v0.1.47
+version: v0.1.48
+appVersion: v0.1.48
 
 icon: https://assets.unikorn-cloud.org/images/logos/dark-on-light/icon.svg

--- a/pkg/authorization/rbac/authorizer.go
+++ b/pkg/authorization/rbac/authorizer.go
@@ -18,104 +18,16 @@ package rbac
 
 import (
 	"context"
-	"crypto/tls"
-	"crypto/x509"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
-	"net/http"
 	"slices"
 
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/propagation"
-
-	"github.com/unikorn-cloud/core/pkg/authorization/accesstoken"
 	"github.com/unikorn-cloud/core/pkg/authorization/constants"
 )
 
 var (
 	ErrPermissionDenied = errors.New("access denied")
-
-	ErrRequestError = errors.New("request error")
-
-	ErrCertError = errors.New("certificate error")
 )
-
-// IdentityACLGetter grabs an ACL for the user from the identity API.
-// Used for any non-identity API.
-type IdentityACLGetter struct {
-	host         string
-	organization string
-	ca           []byte
-}
-
-func NewIdentityACLGetter(host, organization string) *IdentityACLGetter {
-	return &IdentityACLGetter{
-		host:         host,
-		organization: organization,
-	}
-}
-
-func (a *IdentityACLGetter) WithCA(ca []byte) *IdentityACLGetter {
-	a.ca = ca
-
-	return a
-}
-
-func (a *IdentityACLGetter) Get(ctx context.Context) (*ACL, error) {
-	client := &http.Client{}
-
-	// Handle things like let's encrypt staging.
-	if a.ca != nil {
-		certPool := x509.NewCertPool()
-
-		if ok := certPool.AppendCertsFromPEM(a.ca); !ok {
-			return nil, fmt.Errorf("%w: unable to add CA certificate", ErrCertError)
-		}
-
-		client = &http.Client{
-			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{
-					RootCAs:    certPool,
-					MinVersion: tls.VersionTLS13,
-				},
-			},
-		}
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/api/v1/organizations/%s/acl", a.host, a.organization), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Set("Authorization", "bearer "+accesstoken.FromContext(ctx))
-	otel.GetTextMapPropagator().Inject(ctx, propagation.HeaderCarrier(req.Header))
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("%w: status code not as expected", ErrRequestError)
-	}
-
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	acl := &ACL{}
-
-	if err := json.Unmarshal(body, &acl); err != nil {
-		return nil, err
-	}
-
-	return acl, nil
-}
 
 // SuperAdminAuthorizer allows access to everything.
 type SuperAdminAuthorizer struct{}


### PR DESCRIPTION
This was a hack, we should be using the OpenAPI client for identity. But seeing as identity uses core, and core then would have needed identity, we get into a vicious cycle.  This code has now been moved into an RBAC backage to break the dependency.