### PR TITLE
Add Arbirtary Resource Labels

### DIFF
--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn Core
 
 type: application
 
-version: v0.1.54
-appVersion: v0.1.54
+version: v0.1.55
+appVersion: v0.1.55
 
 icon: https://assets.unikorn-cloud.org/images/logos/dark-on-light/icon.svg
 


### PR DESCRIPTION
We've got support for built in labels, add in support for arbirary ones defined by other services.  Also make the auditing API nicer.