### PR TITLE
Revisit Retry Errors

### DIFF
--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn Core
 
 type: application
 
-version: v0.1.60
-appVersion: v0.1.60
+version: v0.1.61
+appVersion: v0.1.61
 
 icon: https://assets.unikorn-cloud.org/images/logos/dark-on-light/icon.svg
 


### PR DESCRIPTION
We need access to potentially both errors from a retry, and as chance may have it, this is now possible due to go supporting error trees, so you can unwrap multiple errors and Is/As will work as you'd expect.