### PR TITLE
Add in Correct Create Auditing

### DIFF
--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn Core
 
 type: application
 
-version: v0.1.61
-appVersion: v0.1.61
+version: v0.1.62
+appVersion: v0.1.62
 
 icon: https://assets.unikorn-cloud.org/images/logos/dark-on-light/icon.svg
 

--- a/pkg/server/middleware/opentelemetry/opentelemetry.go
+++ b/pkg/server/middleware/opentelemetry/opentelemetry.go
@@ -202,10 +202,16 @@ func httpRequestAttributes(r *http.Request) []attribute.KeyValue {
 }
 
 func httpResponseAttributes(w *middleware.LoggingResponseWriter) []attribute.KeyValue {
+	var bodySize int
+
+	if body := w.Body(); body != nil {
+		bodySize = body.Len()
+	}
+
 	var attr []attribute.KeyValue
 
 	attr = append(attr, semconv.HTTPResponseStatusCode(w.StatusCode()))
-	attr = append(attr, semconv.HTTPResponseBodySize(w.ContentLength()))
+	attr = append(attr, semconv.HTTPResponseBodySize(bodySize))
 	attr = append(attr, httpHeaderAttributes(w.Header(), "http.response.header")...)
 
 	return attr

--- a/pkg/server/middleware/types.go
+++ b/pkg/server/middleware/types.go
@@ -17,15 +17,16 @@ limitations under the License.
 package middleware
 
 import (
+	"bytes"
 	"net/http"
 )
 
 // LoggingResponseWriter is the ubiquitous reimplementation of a response
 // writer that allows access to the HTTP status code in middleware.
 type LoggingResponseWriter struct {
-	next          http.ResponseWriter
-	code          int
-	contentLength int
+	next http.ResponseWriter
+	code int
+	body *bytes.Buffer
 }
 
 func NewLoggingResponseWriter(next http.ResponseWriter) *LoggingResponseWriter {
@@ -42,7 +43,11 @@ func (w *LoggingResponseWriter) Header() http.Header {
 }
 
 func (w *LoggingResponseWriter) Write(body []byte) (int, error) {
-	w.contentLength += len(body)
+	if w.body == nil {
+		w.body = &bytes.Buffer{}
+	}
+
+	w.body.Write(body)
 
 	return w.next.Write(body)
 }
@@ -60,6 +65,6 @@ func (w *LoggingResponseWriter) StatusCode() int {
 	return w.code
 }
 
-func (w *LoggingResponseWriter) ContentLength() int {
-	return w.contentLength
+func (w *LoggingResponseWriter) Body() *bytes.Buffer {
+	return w.body
 }


### PR DESCRIPTION
Previously when something was created, we just said exactly that, but we didn't say what, because we had no idea.  Modify the lookup on creation so we have access to the response, can extract the metadata, and get the new ID.  Obviously this means every API will need to be updated...