### PR TITLE
Propagate Remote With Context

### DIFF
--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn Core
 
 type: application
 
-version: v0.1.63
-appVersion: v0.1.63
+version: v0.1.64
+appVersion: v0.1.64
 
 icon: https://assets.unikorn-cloud.org/images/logos/dark-on-light/icon.svg
 

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -27,4 +27,10 @@ var (
 
 	// ErrCDDriver is raised when a CD driver is not handled.
 	ErrCDDriver = errors.New("unhandled CD driver")
+
+	// ErrInvalidContext is raised when the context is not correctly polulated.
+	ErrInvalidContext = errors.New("context invalid")
+
+	// ErrKubeconfig is raised wne the Kubeconfig isn't correct.
+	ErrKubeconfig = errors.New("kubeconfig error")
 )

--- a/pkg/manager/reconcile.go
+++ b/pkg/manager/reconcile.go
@@ -102,10 +102,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	// The static client is used by the application provisioner to get access to
 	// application bundles and definitions regardless of remote cluster scoping etc.
-	ctx = client.NewContextWithStaticClient(ctx, r.manager.GetClient())
+	ctx = client.NewContextWithProvisionerClient(ctx, r.manager.GetClient())
 
-	// The dynamic client context is updated as remote clusters are descended into.
-	ctx = client.NewContextWithDynamicClient(ctx, r.manager.GetClient())
+	// The cluster context is updated as remote clusters are descended into.
+	clusterContext := &client.ClusterContext{
+		// TODO: cluster information.
+		Client: r.manager.GetClient(),
+	}
+
+	ctx = client.NewContextWithCluster(ctx, clusterContext)
 
 	// The driver context is updated as remote provisioners are descended into.
 	ctx = cd.NewContext(ctx, driver)

--- a/pkg/provisioners/application/provisioner_test.go
+++ b/pkg/provisioners/application/provisioner_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/unikorn-cloud/core/pkg/constants"
 	"github.com/unikorn-cloud/core/pkg/provisioners"
 	"github.com/unikorn-cloud/core/pkg/provisioners/application"
-	mockprovisioners "github.com/unikorn-cloud/core/pkg/provisioners/mock"
 	"github.com/unikorn-cloud/core/pkg/util"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -152,8 +151,13 @@ func TestApplicationCreateHelm(t *testing.T) {
 	driver := mock.NewMockDriver(c)
 	owner := newManagedResource()
 
+	clusterContext := &coreclient.ClusterContext{
+		Client: tc.client,
+	}
+
 	ctx := context.Background()
-	ctx = coreclient.NewContextWithStaticClient(ctx, tc.client)
+	ctx = coreclient.NewContextWithProvisionerClient(ctx, tc.client)
+	ctx = coreclient.NewContextWithCluster(ctx, clusterContext)
 	ctx = cd.NewContext(ctx, driver)
 	ctx = application.NewContext(ctx, owner)
 
@@ -224,9 +228,6 @@ func TestApplicationCreateHelmExtended(t *testing.T) {
 		},
 	}
 
-	r := mockprovisioners.NewMockRemoteCluster(c)
-	r.EXPECT().ID().Return(remoteID)
-
 	driverAppID := &cd.ResourceIdentifier{
 		Name:   applicationName,
 		Labels: newManagedResourceLabels(),
@@ -252,15 +253,20 @@ func TestApplicationCreateHelmExtended(t *testing.T) {
 	driver := mock.NewMockDriver(c)
 	owner := newManagedResource()
 
+	clusterContext := &coreclient.ClusterContext{
+		ID:     remoteID,
+		Client: tc.client,
+	}
+
 	ctx := context.Background()
-	ctx = coreclient.NewContextWithStaticClient(ctx, tc.client)
+	ctx = coreclient.NewContextWithProvisionerClient(ctx, tc.client)
+	ctx = coreclient.NewContextWithCluster(ctx, clusterContext)
 	ctx = cd.NewContext(ctx, driver)
 	ctx = application.NewContext(ctx, owner)
 
 	driver.EXPECT().CreateOrUpdateHelmApplication(ctx, driverAppID, driverApp).Return(provisioners.ErrYield)
 
 	provisioner := application.New(getApplicationReference).AllowDegraded()
-	provisioner.OnRemote(r)
 
 	assert.ErrorIs(t, provisioner.Provision(ctx), provisioners.ErrYield)
 }
@@ -310,8 +316,13 @@ func TestApplicationCreateGit(t *testing.T) {
 	driver := mock.NewMockDriver(c)
 	owner := newManagedResource()
 
+	clusterContext := &coreclient.ClusterContext{
+		Client: tc.client,
+	}
+
 	ctx := context.Background()
-	ctx = coreclient.NewContextWithStaticClient(ctx, tc.client)
+	ctx = coreclient.NewContextWithProvisionerClient(ctx, tc.client)
+	ctx = coreclient.NewContextWithCluster(ctx, clusterContext)
 	ctx = cd.NewContext(ctx, driver)
 	ctx = application.NewContext(ctx, owner)
 
@@ -446,8 +457,13 @@ func TestApplicationCreateMutate(t *testing.T) {
 	driver := mock.NewMockDriver(c)
 	owner := newManagedResource()
 
+	clusterContext := &coreclient.ClusterContext{
+		Client: tc.client,
+	}
+
 	ctx := context.Background()
-	ctx = coreclient.NewContextWithStaticClient(ctx, tc.client)
+	ctx = coreclient.NewContextWithProvisionerClient(ctx, tc.client)
+	ctx = coreclient.NewContextWithCluster(ctx, clusterContext)
 	ctx = cd.NewContext(ctx, driver)
 	ctx = application.NewContext(ctx, owner)
 
@@ -499,7 +515,7 @@ func TestApplicationDeleteNotFound(t *testing.T) {
 	owner := newManagedResource()
 
 	ctx := context.Background()
-	ctx = coreclient.NewContextWithStaticClient(ctx, tc.client)
+	ctx = coreclient.NewContextWithProvisionerClient(ctx, tc.client)
 	ctx = cd.NewContext(ctx, driver)
 	ctx = application.NewContext(ctx, owner)
 

--- a/pkg/provisioners/concurrent/provisioner.go
+++ b/pkg/provisioners/concurrent/provisioner.go
@@ -51,14 +51,12 @@ var _ provisioners.Provisioner = &Provisioner{}
 func (p *Provisioner) Provision(ctx context.Context) error {
 	log := log.FromContext(ctx)
 
-	log.Info("provisioning concurrency group", "group", p.Name, "remote", p.Remote)
+	log.Info("provisioning concurrency group", "group", p.Name)
 
 	group := &errgroup.Group{}
 
 	for i := range p.provisioners {
 		provisioner := p.provisioners[i]
-
-		p.PropagateOptions(provisioner)
 
 		callback := func() error {
 			// As errgroup only saves the first error, we may lose some
@@ -97,8 +95,6 @@ func (p *Provisioner) Deprovision(ctx context.Context) error {
 
 	for i := range p.provisioners {
 		provisioner := p.provisioners[i]
-
-		p.PropagateOptions(provisioner)
 
 		callback := func() error {
 			// As errgroup only saves the first error, we may lose some

--- a/pkg/provisioners/concurrent/provisioner_test.go
+++ b/pkg/provisioners/concurrent/provisioner_test.go
@@ -66,31 +66,6 @@ func TestConcurrentProvision(t *testing.T) {
 	assert.NoError(t, concurrent.New("test", p1, p2).Provision(ctx))
 }
 
-// TestConcurrentProvisionPropagate expects remote clusters to be propagated.
-func TestConcurrentProvisionPropagate(t *testing.T) {
-	t.Parallel()
-
-	c := gomock.NewController(t)
-	defer c.Finish()
-
-	ctx := context.Background()
-
-	r := mock.NewMockRemoteCluster(c)
-
-	p1 := mock.NewMockProvisioner(c)
-	p1.EXPECT().OnRemote(r)
-	p1.EXPECT().Provision(ctx).Return(nil)
-
-	p2 := mock.NewMockProvisioner(c)
-	p2.EXPECT().OnRemote(r)
-	p2.EXPECT().Provision(ctx).Return(nil)
-
-	provisioner := concurrent.New("test", p1, p2)
-	provisioner.OnRemote(r)
-
-	assert.NoError(t, provisioner.Provision(ctx))
-}
-
 // TestConcurrentProvisionYieldFirst ensures all provisioners are
 // called and it returns a yield if the first provisioner yields.
 func TestConcurrentProvisionYieldFirst(t *testing.T) {

--- a/pkg/provisioners/conditional/provisioner.go
+++ b/pkg/provisioners/conditional/provisioner.go
@@ -52,8 +52,6 @@ var _ provisioners.Provisioner = &Provisioner{}
 func (p *Provisioner) Provision(ctx context.Context) error {
 	log := log.FromContext(ctx)
 
-	p.PropagateOptions(p.provisioner)
-
 	if !p.condition() {
 		log.Info("conditional deprovision", "provisioner", p.Name)
 
@@ -65,7 +63,5 @@ func (p *Provisioner) Provision(ctx context.Context) error {
 
 // Deprovision implements the Provision interface.
 func (p *Provisioner) Deprovision(ctx context.Context) error {
-	p.PropagateOptions(p.provisioner)
-
 	return p.provisioner.Deprovision(ctx)
 }

--- a/pkg/provisioners/interfaces.go
+++ b/pkg/provisioners/interfaces.go
@@ -45,16 +45,6 @@ type Provisioner interface {
 	// ProvisionerName returns the provisioner name.
 	ProvisionerName() string
 
-	// OnRemote defines this provisioner should be run on the
-	// provided remote cluster.  All composite provisioners must
-	// propagate this.
-	OnRemote(remote RemoteCluster)
-
-	// BackgroundDeletion means we don't care about whether it's deprovisioned
-	// successfully or not, especially useful for apps living in a
-	// remote cluster that going to get terminated anyway.
-	BackgroundDeletion()
-
 	// Provision deploys the requested package.
 	// Implementations should ensure this receiver is idempotent.
 	Provision(ctx context.Context) error

--- a/pkg/provisioners/mock/interfaces.go
+++ b/pkg/provisioners/mock/interfaces.go
@@ -14,7 +14,6 @@ import (
 
 	v1alpha1 "github.com/unikorn-cloud/core/pkg/apis/unikorn/v1alpha1"
 	cd "github.com/unikorn-cloud/core/pkg/cd"
-	provisioners "github.com/unikorn-cloud/core/pkg/provisioners"
 	gomock "go.uber.org/mock/gomock"
 	api "k8s.io/client-go/tools/clientcmd/api"
 )
@@ -94,18 +93,6 @@ func (m *MockProvisioner) EXPECT() *MockProvisionerMockRecorder {
 	return m.recorder
 }
 
-// BackgroundDeletion mocks base method.
-func (m *MockProvisioner) BackgroundDeletion() {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "BackgroundDeletion")
-}
-
-// BackgroundDeletion indicates an expected call of BackgroundDeletion.
-func (mr *MockProvisionerMockRecorder) BackgroundDeletion() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BackgroundDeletion", reflect.TypeOf((*MockProvisioner)(nil).BackgroundDeletion))
-}
-
 // Deprovision mocks base method.
 func (m *MockProvisioner) Deprovision(ctx context.Context) error {
 	m.ctrl.T.Helper()
@@ -118,18 +105,6 @@ func (m *MockProvisioner) Deprovision(ctx context.Context) error {
 func (mr *MockProvisionerMockRecorder) Deprovision(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Deprovision", reflect.TypeOf((*MockProvisioner)(nil).Deprovision), ctx)
-}
-
-// OnRemote mocks base method.
-func (m *MockProvisioner) OnRemote(remote provisioners.RemoteCluster) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "OnRemote", remote)
-}
-
-// OnRemote indicates an expected call of OnRemote.
-func (mr *MockProvisionerMockRecorder) OnRemote(remote any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnRemote", reflect.TypeOf((*MockProvisioner)(nil).OnRemote), remote)
 }
 
 // Provision mocks base method.
@@ -183,18 +158,6 @@ func (m *MockManagerProvisioner) EXPECT() *MockManagerProvisionerMockRecorder {
 	return m.recorder
 }
 
-// BackgroundDeletion mocks base method.
-func (m *MockManagerProvisioner) BackgroundDeletion() {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "BackgroundDeletion")
-}
-
-// BackgroundDeletion indicates an expected call of BackgroundDeletion.
-func (mr *MockManagerProvisionerMockRecorder) BackgroundDeletion() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BackgroundDeletion", reflect.TypeOf((*MockManagerProvisioner)(nil).BackgroundDeletion))
-}
-
 // Deprovision mocks base method.
 func (m *MockManagerProvisioner) Deprovision(ctx context.Context) error {
 	m.ctrl.T.Helper()
@@ -221,18 +184,6 @@ func (m *MockManagerProvisioner) Object() v1alpha1.ManagableResourceInterface {
 func (mr *MockManagerProvisionerMockRecorder) Object() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Object", reflect.TypeOf((*MockManagerProvisioner)(nil).Object))
-}
-
-// OnRemote mocks base method.
-func (m *MockManagerProvisioner) OnRemote(remote provisioners.RemoteCluster) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "OnRemote", remote)
-}
-
-// OnRemote indicates an expected call of OnRemote.
-func (mr *MockManagerProvisionerMockRecorder) OnRemote(remote any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnRemote", reflect.TypeOf((*MockManagerProvisioner)(nil).OnRemote), remote)
 }
 
 // Provision mocks base method.

--- a/pkg/provisioners/remotecluster/context.go
+++ b/pkg/provisioners/remotecluster/context.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2024 the Unikorn Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remotecluster
+
+import (
+	"context"
+)
+
+type key int
+
+const (
+	// backgroundDeletionKey is used to propagate background deletion to
+	// all descendant provisioners in the call graph.
+	backgroundDeletionKey key = iota
+)
+
+func NewContextWithBackgroundDeletion(ctx context.Context, backgroundDeletion bool) context.Context {
+	return context.WithValue(ctx, backgroundDeletionKey, backgroundDeletion)
+}
+
+func BackgroundDeletionFromContext(ctx context.Context) bool {
+	if value := ctx.Value(backgroundDeletionKey); value != nil {
+		if backgroundDeletion, ok := value.(bool); ok {
+			return backgroundDeletion
+		}
+	}
+
+	return false
+}

--- a/pkg/provisioners/resource/resource.go
+++ b/pkg/provisioners/resource/resource.go
@@ -60,13 +60,16 @@ func mutate() error {
 func (p *Provisioner) Provision(ctx context.Context) error {
 	log := log.FromContext(ctx)
 
-	c := clientlib.DynamicClientFromContext(ctx)
+	clusterContext, err := clientlib.ClusterFromContext(ctx)
+	if err != nil {
+		return err
+	}
 
 	objectKey := client.ObjectKeyFromObject(p.resource)
 
 	log.Info("creating object", "key", objectKey)
 
-	result, err := controllerutil.CreateOrUpdate(ctx, c, p.resource, mutate)
+	result, err := controllerutil.CreateOrUpdate(ctx, clusterContext.Client, p.resource, mutate)
 	if err != nil {
 		return err
 	}
@@ -80,13 +83,16 @@ func (p *Provisioner) Provision(ctx context.Context) error {
 func (p *Provisioner) Deprovision(ctx context.Context) error {
 	log := log.FromContext(ctx)
 
-	c := clientlib.DynamicClientFromContext(ctx)
+	clusterContext, err := clientlib.ClusterFromContext(ctx)
+	if err != nil {
+		return err
+	}
 
 	objectKey := client.ObjectKeyFromObject(p.resource)
 
 	log.Info("deleting object", "key", objectKey)
 
-	if err := c.Delete(ctx, p.resource); err != nil {
+	if err := clusterContext.Client.Delete(ctx, p.resource); err != nil {
 		if errors.IsNotFound(err) {
 			log.Info("object deleted", "key", objectKey)
 

--- a/pkg/provisioners/serial/provisioner.go
+++ b/pkg/provisioners/serial/provisioner.go
@@ -48,11 +48,9 @@ var _ provisioners.Provisioner = &Provisioner{}
 func (p *Provisioner) Provision(ctx context.Context) error {
 	log := log.FromContext(ctx)
 
-	log.Info("provisioning serial group", "group", p.Name, "remote", p.Remote)
+	log.Info("provisioning serial group", "group", p.Name)
 
 	for _, provisioner := range p.provisioners {
-		p.PropagateOptions(provisioner)
-
 		if err := provisioner.Provision(ctx); err != nil {
 			log.Info("serial group member exited with error", "error", err, "group", p.Name, "provisioner", provisioner.ProvisionerName())
 
@@ -76,8 +74,6 @@ func (p *Provisioner) Deprovision(ctx context.Context) error {
 
 	for i := range p.provisioners {
 		provisioner := p.provisioners[len(p.provisioners)-(i+1)]
-
-		p.PropagateOptions(provisioner)
 
 		if err := provisioner.Deprovision(ctx); err != nil {
 			log.Info("serial group member exited with error", "error", err, "group", p.Name, "provisioner", provisioner.ProvisionerName())

--- a/pkg/provisioners/types.go
+++ b/pkg/provisioners/types.go
@@ -21,38 +21,9 @@ package provisioners
 type Metadata struct {
 	// Name is the name of the provisioner.
 	Name string
-
-	// Remote is the remote cluster a resource or group of resources
-	// belongs to.
-	Remote RemoteCluster
-
-	// BackgroundDelete means we don't care about whether it's deprovisioned
-	// successfully or not, especially useful for apps living in a
-	// remote cluster that going to get terminated anyway.
-	BackgroundDelete bool
 }
 
 // ProvisionerName implements the Provisioner interface.
 func (p *Metadata) ProvisionerName() string {
 	return p.Name
-}
-
-func (p *Metadata) OnRemote(remote RemoteCluster) {
-	p.Remote = remote
-}
-
-func (p *Metadata) BackgroundDeletion() {
-	p.BackgroundDelete = true
-}
-
-// PropagateOptions allows provisioners to push options down to
-// all their children.
-func (p *Metadata) PropagateOptions(provisioner Provisioner) {
-	if p.Remote != nil {
-		provisioner.OnRemote(p.Remote)
-	}
-
-	if p.BackgroundDelete {
-		provisioner.BackgroundDeletion()
-	}
 }

--- a/pkg/provisioners/util/util.go
+++ b/pkg/provisioners/util/util.go
@@ -18,38 +18,15 @@ limitations under the License.
 package util
 
 import (
-	"context"
 	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
-
-	clientlib "github.com/unikorn-cloud/core/pkg/client"
-
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/labels"
-
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var (
 	ErrNamespaceLookup = errors.New("unable to lookup namespace")
 )
-
-func GetResourceNamespace(ctx context.Context, l labels.Set) (*corev1.Namespace, error) {
-	c := clientlib.StaticClientFromContext(ctx)
-
-	namespaces := &corev1.NamespaceList{}
-	if err := c.List(ctx, namespaces, &client.ListOptions{LabelSelector: l.AsSelector()}); err != nil {
-		return nil, err
-	}
-
-	if len(namespaces.Items) != 1 {
-		return nil, fmt.Errorf("%w: labels %v", ErrNamespaceLookup, l)
-	}
-
-	return &namespaces.Items[0], nil
-}
 
 // GetConfigurationHash is used to restart badly behaved apps that don't respect configuration
 // changes.


### PR DESCRIPTION
We already do this with Kubernetes clients, where they are attached to the context and propagated to descendant provisioners so the scope magically updates as we traverse the call graph.  Do the same for the remote, which a) makes things cleaner and we don't need to manually propagate to child metadata, and b) gives you access to a whole host more information e.g. the Kubernetes endpoint for troublesome provisioners such as Cilium.  While we are here, remove the simpliar abomination that this background deletion.