### PR TITLE
Make Annotation Preservation Optional

### DIFF
--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn Core
 
 type: application
 
-version: v0.1.67
-appVersion: v0.1.67
+version: v0.1.68
+appVersion: v0.1.68
 
 icon: https://assets.unikorn-cloud.org/images/logos/dark-on-light/icon.svg
 


### PR DESCRIPTION
While a good idea from a bug prevention standpoint, it didn't allow optional annotations, so loosen the requirements for now, until it's a problem.