### PR TITLE
Make UUID Generator Library

### DIFF
--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn Core
 
 type: application
 
-version: v0.1.70
-appVersion: v0.1.70
+version: v0.1.71
+appVersion: v0.1.71
 
 icon: https://assets.unikorn-cloud.org/images/logos/dark-on-light/icon.svg
 

--- a/pkg/server/conversion/conversion.go
+++ b/pkg/server/conversion/conversion.go
@@ -20,14 +20,13 @@ import (
 	"errors"
 	"fmt"
 	"time"
-	"unicode"
 
 	unikornv1 "github.com/unikorn-cloud/core/pkg/apis/unikorn/v1alpha1"
 	"github.com/unikorn-cloud/core/pkg/constants"
 	"github.com/unikorn-cloud/core/pkg/openapi"
+	"github.com/unikorn-cloud/core/pkg/util"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/uuid"
 )
 
 var (
@@ -134,18 +133,6 @@ func ProjectScopedResourceReadMetadata(in metav1.Object, status openapi.Resource
 	return out
 }
 
-// generateResourceID creates a valid Kubernetes name from a UUID.
-func generateResourceID() string {
-	for {
-		// NOTE: Kubernetes UUIDs are based on version 4, aka random,
-		// so the first character will be a letter eventually, like
-		// a 6/16 chance: tl;dr infinite loops are... improbable.
-		if id := uuid.NewUUID(); unicode.IsLetter(rune(id[0])) {
-			return string(id)
-		}
-	}
-}
-
 // ObjectMetadata implements a builder pattern.
 type ObjectMetadata metav1.ObjectMeta
 
@@ -153,7 +140,7 @@ type ObjectMetadata metav1.ObjectMeta
 func NewObjectMetadata(metadata *openapi.ResourceWriteMetadata, namespace, actor string) *ObjectMetadata {
 	o := &ObjectMetadata{
 		Namespace: namespace,
-		Name:      generateResourceID(),
+		Name:      util.GenerateResourceID(),
 		Labels: map[string]string{
 			constants.NameLabel: metadata.Name,
 		},

--- a/pkg/util/resource.go
+++ b/pkg/util/resource.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2024 the Unikorn Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"unicode"
+
+	"k8s.io/apimachinery/pkg/util/uuid"
+)
+
+// GenerateResourceID creates a valid Kubernetes name from a UUID.
+func GenerateResourceID() string {
+	for {
+		// NOTE: Kubernetes UUIDs are based on version 4, aka random,
+		// so the first character will be a letter eventually, like
+		// a 6/16 chance: tl;dr infinite loops are... improbable.
+		if id := uuid.NewUUID(); unicode.IsLetter(rune(id[0])) {
+			return string(id)
+		}
+	}
+}


### PR DESCRIPTION
THings other than APIs need to be able to generate Kubernetes name compatible UUIDs, mainly for initial system configuration.