### PR TITLE
Make Applications Namespaced

### DIFF
--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -4,12 +4,12 @@ description: A Helm chart for deploying Unikorn Core
 
 type: application
 
-version: v0.1.71
-appVersion: v0.1.71
+version: v0.1.72
+appVersion: v0.1.72
 
 icon: https://assets.unikorn-cloud.org/images/logos/dark-on-light/icon.svg
 
 dependencies:
 - name: unikorn-common
-  version: v0.1.6
+  version: v0.1.12
   repository: https://unikorn-cloud.github.io/helm-common

--- a/charts/core/crds/unikorn-cloud.org_helmapplications.yaml
+++ b/charts/core/crds/unikorn-cloud.org_helmapplications.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.3
   name: helmapplications.unikorn-cloud.org
 spec:
   group: unikorn-cloud.org
@@ -14,7 +14,7 @@ spec:
     listKind: HelmApplicationList
     plural: helmapplications
     singular: helmapplication
-  scope: Cluster
+  scope: Namespaced
   versions:
   - additionalPrinterColumns:
     - jsonPath: .metadata.labels['unikorn-cloud\.org/name']

--- a/pkg/apis/unikorn/v1alpha1/helmapplication_types.go
+++ b/pkg/apis/unikorn/v1alpha1/helmapplication_types.go
@@ -31,9 +31,8 @@ type HelmApplicationList struct {
 
 // HelmApplication defines a Helm application.
 // +genclient
-// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:scope=Cluster,categories=unikorn
+// +kubebuilder:resource:scope=Namespaced,categories=unikorn
 // +kubebuilder:printcolumn:name="display name",type="string",JSONPath=".metadata.labels['unikorn-cloud\\.org/name']"
 // +kubebuilder:printcolumn:name="age",type="date",JSONPath=".metadata.creationTimestamp"
 type HelmApplication struct {

--- a/pkg/client/context.go
+++ b/pkg/client/context.go
@@ -56,6 +56,9 @@ const (
 	// clusterKey sets the cluster so it's propagated to all
 	// descendant provisioners in the call graph.
 	clusterKey
+
+	// namespaceKey is used to propagate the process's namespace to clients.
+	namespaceKey
 )
 
 func NewContextWithProvisionerClient(ctx context.Context, client client.Client) context.Context {
@@ -84,4 +87,18 @@ func ClusterFromContext(ctx context.Context) (*ClusterContext, error) {
 	}
 
 	return nil, errors.ErrInvalidContext
+}
+
+func NewContextWithNamespace(ctx context.Context, namespace string) context.Context {
+	return context.WithValue(ctx, namespaceKey, namespace)
+}
+
+func NamespaceFromContext(ctx context.Context) (string, error) {
+	if value := ctx.Value(namespaceKey); value != nil {
+		if namespace, ok := value.(string); ok {
+			return namespace, nil
+		}
+	}
+
+	return "", errors.ErrInvalidContext
 }

--- a/pkg/manager/options/options.go
+++ b/pkg/manager/options/options.go
@@ -25,6 +25,9 @@ import (
 
 // Options defines common controller options.
 type Options struct {
+	// Namespace is the namespace we are running in.
+	Namespace string
+
 	// MaxConcurrentReconciles allows requests to be processed
 	// concurrently.  Be warned, this will inrcrease memory utilization
 	// and may need to update the Helm limits.
@@ -38,6 +41,7 @@ type Options struct {
 func (o *Options) AddFlags(flags *pflag.FlagSet) {
 	o.CDDriver.Kind = cd.DriverKindArgoCD
 
-	flags.IntVar(&o.MaxConcurrentReconciles, "--max-concurrency", 16, "Maximum number of requests to process at the same time")
-	flags.Var(&o.CDDriver, "--cd-driver", "CD backend driver to use from [argocd]")
+	flags.StringVar(&o.Namespace, "namespace", "", "Namespace the process is running in")
+	flags.IntVar(&o.MaxConcurrentReconciles, "max-concurrency", 16, "Maximum number of requests to process at the same time")
+	flags.Var(&o.CDDriver, "cd-driver", "CD backend driver to use from [argocd]")
 }

--- a/pkg/manager/reconcile.go
+++ b/pkg/manager/reconcile.go
@@ -104,6 +104,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	// Add the manager to grant access to eventing.
 	ctx = NewContext(ctx, r.manager)
 
+	// The namespace allows access to the current namespace to lookup any
+	// namespace scoped resources.
+	ctx = client.NewContextWithNamespace(ctx, r.options.Namespace)
+
 	// The static client is used by the application provisioner to get access to
 	// application bundles and definitions regardless of remote cluster scoping etc.
 	ctx = client.NewContextWithProvisionerClient(ctx, r.manager.GetClient())

--- a/pkg/provisioners/application/provisioner.go
+++ b/pkg/provisioners/application/provisioner.go
@@ -282,13 +282,19 @@ func (p *Provisioner) initialize(ctx context.Context) error {
 		return err
 	}
 
+	namespace, err := clientlib.NamespaceFromContext(ctx)
+	if err != nil {
+		return err
+	}
+
 	cli, err := clientlib.ProvisionerClientFromContext(ctx)
 	if err != nil {
 		return err
 	}
 
 	key := client.ObjectKey{
-		Name: *ref.Name,
+		Namespace: namespace,
+		Name:      *ref.Name,
 	}
 
 	// TODO: Take the kind into consideration??

--- a/pkg/provisioners/application/provisioner_test.go
+++ b/pkg/provisioners/application/provisioner_test.go
@@ -91,6 +91,7 @@ func mustNewTestContext(t *testing.T, objects ...client.Object) *testContext {
 }
 
 const (
+	baseNamespace   = "scooby-doo"
 	applicationID   = "c785837a-7412-49a6-ac7e-6d75ab6ca577"
 	applicationName = "test"
 	repo            = "foo"
@@ -115,7 +116,8 @@ func TestApplicationCreateHelm(t *testing.T) {
 
 	app := &unikornv1.HelmApplication{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: applicationID,
+			Namespace: baseNamespace,
+			Name:      applicationID,
 			Labels: map[string]string{
 				constants.NameLabel: applicationName,
 			},
@@ -156,6 +158,7 @@ func TestApplicationCreateHelm(t *testing.T) {
 	}
 
 	ctx := context.Background()
+	ctx = coreclient.NewContextWithNamespace(ctx, baseNamespace)
 	ctx = coreclient.NewContextWithProvisionerClient(ctx, tc.client)
 	ctx = coreclient.NewContextWithCluster(ctx, clusterContext)
 	ctx = cd.NewContext(ctx, driver)
@@ -184,7 +187,8 @@ func TestApplicationCreateHelmExtended(t *testing.T) {
 
 	app := &unikornv1.HelmApplication{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: applicationID,
+			Namespace: baseNamespace,
+			Name:      applicationID,
 			Labels: map[string]string{
 				constants.NameLabel: applicationName,
 			},
@@ -259,6 +263,7 @@ func TestApplicationCreateHelmExtended(t *testing.T) {
 	}
 
 	ctx := context.Background()
+	ctx = coreclient.NewContextWithNamespace(ctx, baseNamespace)
 	ctx = coreclient.NewContextWithProvisionerClient(ctx, tc.client)
 	ctx = coreclient.NewContextWithCluster(ctx, clusterContext)
 	ctx = cd.NewContext(ctx, driver)
@@ -280,7 +285,8 @@ func TestApplicationCreateGit(t *testing.T) {
 
 	app := &unikornv1.HelmApplication{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: applicationID,
+			Namespace: baseNamespace,
+			Name:      applicationID,
 			Labels: map[string]string{
 				constants.NameLabel: applicationName,
 			},
@@ -321,6 +327,7 @@ func TestApplicationCreateGit(t *testing.T) {
 	}
 
 	ctx := context.Background()
+	ctx = coreclient.NewContextWithNamespace(ctx, baseNamespace)
 	ctx = coreclient.NewContextWithProvisionerClient(ctx, tc.client)
 	ctx = coreclient.NewContextWithCluster(ctx, clusterContext)
 	ctx = cd.NewContext(ctx, driver)
@@ -403,7 +410,8 @@ func TestApplicationCreateMutate(t *testing.T) {
 
 	app := &unikornv1.HelmApplication{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: applicationID,
+			Namespace: baseNamespace,
+			Name:      applicationID,
 			Labels: map[string]string{
 				constants.NameLabel: applicationName,
 			},
@@ -462,6 +470,7 @@ func TestApplicationCreateMutate(t *testing.T) {
 	}
 
 	ctx := context.Background()
+	ctx = coreclient.NewContextWithNamespace(ctx, baseNamespace)
 	ctx = coreclient.NewContextWithProvisionerClient(ctx, tc.client)
 	ctx = coreclient.NewContextWithCluster(ctx, clusterContext)
 	ctx = cd.NewContext(ctx, driver)
@@ -484,7 +493,8 @@ func TestApplicationDeleteNotFound(t *testing.T) {
 
 	app := &unikornv1.HelmApplication{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: applicationID,
+			Namespace: baseNamespace,
+			Name:      applicationID,
 			Labels: map[string]string{
 				constants.NameLabel: applicationName,
 			},
@@ -515,6 +525,7 @@ func TestApplicationDeleteNotFound(t *testing.T) {
 	owner := newManagedResource()
 
 	ctx := context.Background()
+	ctx = coreclient.NewContextWithNamespace(ctx, baseNamespace)
 	ctx = coreclient.NewContextWithProvisionerClient(ctx, tc.client)
 	ctx = cd.NewContext(ctx, driver)
 	ctx = application.NewContext(ctx, owner)


### PR DESCRIPTION
With both the Kubernetes service and the Application service using HelmApplication resources, this introduces a problem where both services will need to define applications, possibly the same ones.  This is your standard split-brain problem, and one kinda worrying from a service support perspective as a modification in one may have wide ranging repercussions for the other.  Simple fix is to just namespace the resources, so that each can independently manage their own application sets.  This does however require that all controllers have the current namespace available to read their application resources.