### PR TITLE
Create Labels for Applications

### DIFF
--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn Core
 
 type: application
 
-version: v0.1.73
-appVersion: v0.1.73
+version: v0.1.74
+appVersion: v0.1.74
 
 icon: https://assets.unikorn-cloud.org/images/logos/dark-on-light/icon.svg
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -68,6 +68,9 @@ const (
 	// KindLabelValueComputeCluster is used to denote a resource belongs to this type.
 	KindLabelValueComputeCluster = "baremetalcluster"
 
+	// KindLabelValueApplicationSet is userd to denote a resource belongs to this type.
+	KindLabelValueApplicationSet = "applicationset"
+
 	// OrganizationLabel is a label applied to namespaces to indicate it is under
 	// control of this tool.  Useful for label selection.
 	OrganizationLabel = "unikorn-cloud.org/organization"
@@ -87,6 +90,10 @@ const (
 	// ApplicationLabel is applied to ArgoCD applications to differentiate
 	// between them.
 	ApplicationLabel = "unikorn-cloud.org/application"
+
+	// ApplicationSetLabel is applied to applications created by application
+	// sets to differentiate between them.
+	ApplicationSetLabel = "unikorn-cloud.org/applicationset"
 
 	// ApplicationIDLabel is used to lookup applications based on their ID.
 	ApplicationIDLabel = "unikorn-cloud.org/application-id"


### PR DESCRIPTION
We need at least a kind label to separate applicationset applications from those defined for clusters and cluster managers.