### PR TITLE
Make Applications Dumb

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -21,6 +21,8 @@ linters:
   - perfsprint
   - testifylint
   - mnd
+  - exportloopref
+  - execinquery
 linters-settings:
   gci:
     sections:

--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn Core
 
 type: application
 
-version: v0.1.80
-appVersion: v0.1.80
+version: v0.1.81
+appVersion: v0.1.81
 
 icon: https://assets.unikorn-cloud.org/images/logos/dark-on-light/icon.svg
 

--- a/pkg/provisioners/application/interfaces.go
+++ b/pkg/provisioners/application/interfaces.go
@@ -20,15 +20,8 @@ package application
 import (
 	"context"
 
-	unikornv1 "github.com/unikorn-cloud/core/pkg/apis/unikorn/v1alpha1"
 	"github.com/unikorn-cloud/core/pkg/cd"
 )
-
-// ApplicationGetter abstracts away how an application is looked up for a
-// specific entity.  Where user defined and unikorn defined application bundles
-// collide is at the ApplicationReference, so that's where we hook in this
-// abstraction.
-type GetterFunc func(ctx context.Context) (*unikornv1.ApplicationReference, error)
 
 // ReleaseNamer is an interface that allows generators to supply an implicit release
 // name to Helm.


### PR DESCRIPTION
They did a lot of messing around with references, which is all well and good for the Kubernetes service, but not for the application service that already has the correct reference and version, so implify the implmenetation and make use more broad.