### PR TITLE
Add Application Namespaces

### DIFF
--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn Core
 
 type: application
 
-version: v0.1.81
-appVersion: v0.1.81
+version: v0.1.82
+appVersion: v0.1.82
 
 icon: https://assets.unikorn-cloud.org/images/logos/dark-on-light/icon.svg
 

--- a/charts/core/crds/unikorn-cloud.org_helmapplications.yaml
+++ b/charts/core/crds/unikorn-cloud.org_helmapplications.yaml
@@ -113,6 +113,10 @@ spec:
                         is going to be bloody tricky without some proper code to handle it.
                         If not set, uses the application default.
                       type: string
+                    namespace:
+                      description: Namespace is the namespace to install the application
+                        to.
+                      type: string
                     parameters:
                       description: |-
                         Parameters is a set of static --set parameters to pass to the chart.

--- a/pkg/apis/unikorn/v1alpha1/helmapplication_types.go
+++ b/pkg/apis/unikorn/v1alpha1/helmapplication_types.go
@@ -79,6 +79,8 @@ type HelmApplicationVersion struct {
 	// Parameters is a set of static --set parameters to pass to the chart.
 	// If not set, uses the application default.
 	Parameters []HelmApplicationParameter `json:"parameters,omitempty"`
+	// Namespace is the namespace to install the application to.
+	Namespace *string `json:"namespace,omitempty"`
 	// CreateNamespace indicates whether the chart requires a namespace to be
 	// created by the tooling, rather than the chart itself.
 	// If not set, uses the application default.

--- a/pkg/apis/unikorn/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/unikorn/v1alpha1/zz_generated.deepcopy.go
@@ -303,6 +303,11 @@ func (in *HelmApplicationVersion) DeepCopyInto(out *HelmApplicationVersion) {
 		*out = make([]HelmApplicationParameter, len(*in))
 		copy(*out, *in)
 	}
+	if in.Namespace != nil {
+		in, out := &in.Namespace, &out.Namespace
+		*out = new(string)
+		**out = **in
+	}
 	if in.CreateNamespace != nil {
 		in, out := &in.CreateNamespace, &out.CreateNamespace
 		*out = new(bool)

--- a/pkg/provisioners/application/provisioner.go
+++ b/pkg/provisioners/application/provisioner.go
@@ -210,6 +210,18 @@ func (p *Provisioner) getClusterID(ctx context.Context) (*cd.ResourceIdentifier,
 	return clusterContext.ID, nil
 }
 
+func (p *Provisioner) getNamespace() string {
+	if p.namespace != "" {
+		return p.namespace
+	}
+
+	if p.applicationVersion.Namespace != nil {
+		return *p.applicationVersion.Namespace
+	}
+
+	return "default"
+}
+
 // generateApplication converts the provided object to a canonical form for a driver.
 //
 //nolint:cyclop
@@ -236,7 +248,7 @@ func (p *Provisioner) generateApplication(ctx context.Context) (*cd.HelmApplicat
 		Parameters:    parameters,
 		Values:        values,
 		Cluster:       clusterID,
-		Namespace:     p.namespace,
+		Namespace:     p.getNamespace(),
 		AllowDegraded: p.allowDegraded,
 	}
 

--- a/pkg/provisioners/application/provisioner_test.go
+++ b/pkg/provisioners/application/provisioner_test.go
@@ -147,9 +147,10 @@ func TestApplicationCreateHelm(t *testing.T) {
 	}
 
 	driverApp := &cd.HelmApplication{
-		Repo:    repo,
-		Chart:   chart,
-		Version: version.Original(),
+		Repo:      repo,
+		Chart:     chart,
+		Version:   version.Original(),
+		Namespace: "default",
 	}
 
 	driver := mock.NewMockDriver(c)
@@ -251,6 +252,7 @@ func TestApplicationCreateHelmExtended(t *testing.T) {
 			},
 		},
 		Cluster:         remoteID,
+		Namespace:       "default",
 		CreateNamespace: true,
 		ServerSideApply: true,
 		AllowDegraded:   true,
@@ -318,10 +320,11 @@ func TestApplicationCreateGit(t *testing.T) {
 	}
 
 	driverApp := &cd.HelmApplication{
-		Repo:    repo,
-		Path:    path,
-		Version: version.Original(),
-		Branch:  branch,
+		Repo:      repo,
+		Path:      path,
+		Version:   version.Original(),
+		Branch:    branch,
+		Namespace: "default",
 	}
 
 	driver := mock.NewMockDriver(c)


### PR DESCRIPTION
Allow applications to set the namespace they are installed in.  An explicit namespace takes precedence, and there is a fallback to default now.