### PR TITLE
Add New Resource Labels

### DIFF
--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn Core
 
 type: application
 
-version: v0.1.89-rc3
-appVersion: v0.1.89-rc3
+version: v0.1.89-rc4
+appVersion: v0.1.89-rc4
 
 icon: https://assets.unikorn-cloud.org/images/logos/dark-on-light/icon.svg
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -111,6 +111,16 @@ const (
 	// context of a region controller) that a recource owns.
 	PhysicalNetworkAnnotation = "unikorn-cloud.org/physical-network-id"
 
+	// ReferencedResourceKindLabel is used when a resource refers to another,
+	// but not necessarily a Kubernetes resource.  It has the added benefit it
+	// can be used as a label selector.
+	ReferencedResourceKindLabel = "unikorn-cloud.org/resource-kind"
+
+	// ReferencedResourceIDLabel is used when a resource refers to another,
+	// but not necessarily a Kubernetes resource.  It has the added benefit it
+	// can be used as a label selector.
+	ReferencedResourceIDLabel = "unikorn-cloud.org/resource-id"
+
 	// Finalizer is applied to resources that need to be deleted manually
 	// and do other complex logic.
 	Finalizer = "unikorn"


### PR DESCRIPTION
Quota allocations for example are owned by a resource e.g. a Kubernetes cluster.  We need to be able to see what allocation is owned by what resource, and also have a performant way of looking up the allocation that's onwed by a resource for updates etc. Thus labels!  Usually we'd use a Kubernetes core object reference, but to be flexible we envisage quotas being defined by 3rd party services too, so keep it flexible.