### PR TITLE
Make Application Interface a Semver

### DIFF
--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn Core
 
 type: application
 
-version: v0.1.92
-appVersion: v0.1.92
+version: v0.1.93-rc1
+appVersion: v0.1.93-rc1
 
 icon: https://assets.unikorn-cloud.org/images/logos/dark-on-light/icon.svg
 

--- a/charts/core/crds/unikorn-cloud.org_helmapplications.yaml
+++ b/charts/core/crds/unikorn-cloud.org_helmapplications.yaml
@@ -110,17 +110,6 @@ spec:
                         - name
                         type: object
                       type: array
-                    interface:
-                      description: |-
-                        Interface is the name of a Unikorn function that configures the application.
-                        In particular it's used when reading values from a custom resource and mapping
-                        them to Helm values.  This allows us to version Helm interfaces in the context
-                        of "do we need to do something differently", without having to come up with a
-                        generalized solution that purely exists as Kubernetes resource specifications.
-                        For example, building a Openstack Cloud Provider configuration from a clouds.yaml
-                        is going to be bloody tricky without some proper code to handle it.
-                        If not set, uses the application default.
-                      type: string
                     namespace:
                       description: Namespace is the namespace to install the application
                         to.

--- a/pkg/apis/unikorn/v1alpha1/helmapplication_types.go
+++ b/pkg/apis/unikorn/v1alpha1/helmapplication_types.go
@@ -89,15 +89,6 @@ type HelmApplicationVersion struct {
 	// controllers modifying the spec mess this up.
 	// If not set, uses the application default.
 	ServerSideApply *bool `json:"serverSideApply,omitempty"`
-	// Interface is the name of a Unikorn function that configures the application.
-	// In particular it's used when reading values from a custom resource and mapping
-	// them to Helm values.  This allows us to version Helm interfaces in the context
-	// of "do we need to do something differently", without having to come up with a
-	// generalized solution that purely exists as Kubernetes resource specifications.
-	// For example, building a Openstack Cloud Provider configuration from a clouds.yaml
-	// is going to be bloody tricky without some proper code to handle it.
-	// If not set, uses the application default.
-	Interface *string `json:"interface,omitempty"`
 	// Dependencies capture hard dependencies on other applications that must
 	// be installed before this one.
 	Dependencies []HelmApplicationDependency `json:"dependencies,omitempty"`

--- a/pkg/apis/unikorn/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/unikorn/v1alpha1/zz_generated.deepcopy.go
@@ -318,11 +318,6 @@ func (in *HelmApplicationVersion) DeepCopyInto(out *HelmApplicationVersion) {
 		*out = new(bool)
 		**out = **in
 	}
-	if in.Interface != nil {
-		in, out := &in.Interface, &out.Interface
-		*out = new(string)
-		**out = **in
-	}
 	if in.Dependencies != nil {
 		in, out := &in.Dependencies, &out.Dependencies
 		*out = make([]HelmApplicationDependency, len(*in))

--- a/pkg/provisioners/application/interfaces.go
+++ b/pkg/provisioners/application/interfaces.go
@@ -39,19 +39,19 @@ type ReleaseNamer interface {
 // present, there is nothing special about overriding, it just appends, so ensure the
 // explicit and implicit sets don't overlap.
 type Paramterizer interface {
-	Parameters(ctx context.Context, version *string) (map[string]string, error)
+	Parameters(ctx context.Context, version unikornv1.SemanticVersion) (map[string]string, error)
 }
 
 // ValuesGenerator is an interface that allows generators to supply a raw values.yaml
 // file to Helm.  This accepts an object that can be marshaled to YAML.
 type ValuesGenerator interface {
-	Values(ctx context.Context, version *string) (interface{}, error)
+	Values(ctx context.Context, version unikornv1.SemanticVersion) (interface{}, error)
 }
 
 // Customizer is a generic generator interface that implemnets raw customizations to
 // the application template.  Try to avoid using this.
 type Customizer interface {
-	Customize(version *string) ([]cd.HelmApplicationField, error)
+	Customize(version unikornv1.SemanticVersion) ([]cd.HelmApplicationField, error)
 }
 
 // PostProvisionHook is an interface that lets an application provisioner run

--- a/pkg/provisioners/application/provisioner.go
+++ b/pkg/provisioners/application/provisioner.go
@@ -156,7 +156,7 @@ func (p *Provisioner) getParameters(ctx context.Context) ([]cd.HelmApplicationPa
 
 	if p.generator != nil {
 		if parameterizer, ok := p.generator.(Paramterizer); ok {
-			p, err := parameterizer.Parameters(ctx, p.applicationVersion.Interface)
+			p, err := parameterizer.Parameters(ctx, p.applicationVersion.Version)
 			if err != nil {
 				return nil, err
 			}
@@ -192,7 +192,7 @@ func (p *Provisioner) getValues(ctx context.Context) (interface{}, error) {
 		return nil, nil
 	}
 
-	values, err := valuesGenerator.Values(ctx, p.applicationVersion.Interface)
+	values, err := valuesGenerator.Values(ctx, p.applicationVersion.Version)
 	if err != nil {
 		return nil, err
 	}
@@ -274,7 +274,7 @@ func (p *Provisioner) generateApplication(ctx context.Context) (*cd.HelmApplicat
 
 	if p.generator != nil {
 		if customization, ok := p.generator.(Customizer); ok {
-			ignoredDifferences, err := customization.Customize(p.applicationVersion.Interface)
+			ignoredDifferences, err := customization.Customize(p.applicationVersion.Version)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/provisioners/application/provisioner_test.go
+++ b/pkg/provisioners/application/provisioner_test.go
@@ -377,7 +377,7 @@ func (m *mutator) ReleaseName(ctx context.Context) string {
 	return "sentinel"
 }
 
-func (m *mutator) Parameters(ctx context.Context, version *string) (map[string]string, error) {
+func (m *mutator) Parameters(ctx context.Context, version unikornv1.SemanticVersion) (map[string]string, error) {
 	p := map[string]string{
 		mutatorParameter: mutatorValue,
 	}
@@ -385,11 +385,11 @@ func (m *mutator) Parameters(ctx context.Context, version *string) (map[string]s
 	return p, nil
 }
 
-func (m *mutator) Values(ctx context.Context, version *string) (interface{}, error) {
+func (m *mutator) Values(ctx context.Context, version unikornv1.SemanticVersion) (interface{}, error) {
 	return mutatorValues, nil
 }
 
-func (m *mutator) Customize(version *string) ([]cd.HelmApplicationField, error) {
+func (m *mutator) Customize(version unikornv1.SemanticVersion) ([]cd.HelmApplicationField, error) {
 	differences := []cd.HelmApplicationField{
 		{
 			Group: mutatorIgnoreDifferencesGroup,


### PR DESCRIPTION
This is the correct level of abstraction as it allows the use of proper compare functions.  Perhaps this was over engineering in the first instance as we could just use the chart version now as that's now forced to be a semantic version these days.  Baby steps!