### PR TITLE
Remove `interface{}`

### DIFF
--- a/hack/docs-generate/main.go
+++ b/hack/docs-generate/main.go
@@ -81,7 +81,7 @@ func loadVariables(config *Config) (map[string]any, error) {
 				return nil, err
 			}
 
-			var document interface{}
+			var document any
 
 			if err := yaml.Unmarshal(data, &document); err != nil {
 				return nil, err

--- a/hack/validate_openapi/main.go
+++ b/hack/validate_openapi/main.go
@@ -29,7 +29,7 @@ import (
 //nolint:gochecknoglobals
 var failed bool
 
-func report(v ...interface{}) {
+func report(v ...any) {
 	fmt.Println(v...)
 
 	failed = true

--- a/pkg/apis/unikorn/v1alpha1/types.go
+++ b/pkg/apis/unikorn/v1alpha1/types.go
@@ -59,7 +59,7 @@ func (v SemanticVersion) MarshalJSON() ([]byte, error) {
 	return json.Marshal(v.Original())
 }
 
-func (v SemanticVersion) ToUnstructured() interface{} {
+func (v SemanticVersion) ToUnstructured() any {
 	return v.Original()
 }
 
@@ -99,7 +99,7 @@ func (c SemanticVersionConstraints) MarshalJSON() ([]byte, error) {
 	return json.Marshal(c.Constraints.String())
 }
 
-func (c SemanticVersionConstraints) ToUnstructured() interface{} {
+func (c SemanticVersionConstraints) ToUnstructured() any {
 	return c.Constraints.String()
 }
 
@@ -147,7 +147,7 @@ func (a IPv4Address) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a.IP.String())
 }
 
-func (a IPv4Address) ToUnstructured() interface{} {
+func (a IPv4Address) ToUnstructured() any {
 	return a.IP.String()
 }
 
@@ -215,7 +215,7 @@ func (p IPv4Prefix) MarshalJSON() ([]byte, error) {
 	return json.Marshal(p.IPNet.String())
 }
 
-func (p IPv4Prefix) ToUnstructured() interface{} {
+func (p IPv4Prefix) ToUnstructured() any {
 	return p.IP.String()
 }
 

--- a/pkg/cd/argocd/driver_test.go
+++ b/pkg/cd/argocd/driver_test.go
@@ -158,7 +158,7 @@ func TestApplicationCreateHelmExtended(t *testing.T) {
 	remoteDestination := fmt.Sprintf("%s-%s:%s", remoteClusterName, remoteClusterLabel1, remoteClusterLabel2)
 	valuesKey := "dog"
 	valuesValue := "woof"
-	values := map[string]interface{}{
+	values := map[string]any{
 		valuesKey: valuesValue,
 	}
 

--- a/pkg/cd/types.go
+++ b/pkg/cd/types.go
@@ -104,8 +104,8 @@ type HelmApplication struct {
 	// Values is an interface to an arbitrary data structure that can
 	// be marshaled into a values.yaml file. The idea here is you can
 	// generate values file data types from a values.schema.json, or
-	// just thown in a free-form map[string]interface{} thing.
-	Values interface{}
+	// just throw in a free-form map[string]any thing.
+	Values any
 
 	// Cluster identifies the cluster to install on to.
 	// By definition we require the CD provider to support multiple

--- a/pkg/provisioners/application/interfaces.go
+++ b/pkg/provisioners/application/interfaces.go
@@ -45,7 +45,7 @@ type Paramterizer interface {
 // ValuesGenerator is an interface that allows generators to supply a raw values.yaml
 // file to Helm.  This accepts an object that can be marshaled to YAML.
 type ValuesGenerator interface {
-	Values(ctx context.Context, version unikornv1.SemanticVersion) (interface{}, error)
+	Values(ctx context.Context, version unikornv1.SemanticVersion) (any, error)
 }
 
 // Customizer is a generic generator interface that implemnets raw customizations to

--- a/pkg/provisioners/application/provisioner.go
+++ b/pkg/provisioners/application/provisioner.go
@@ -48,7 +48,7 @@ type Provisioner struct {
 	namespace string
 
 	// generator provides application generation functionality.
-	generator interface{}
+	generator any
 
 	// allowDegraded accepts a degraded status as a success for an application.
 	allowDegraded bool
@@ -79,7 +79,7 @@ func (p *Provisioner) InNamespace(namespace string) *Provisioner {
 
 // WithGenerator registers an object that can generate implicit configuration where
 // you cannot do it all from the default set of arguments.
-func (p *Provisioner) WithGenerator(generator interface{}) *Provisioner {
+func (p *Provisioner) WithGenerator(generator any) *Provisioner {
 	p.generator = generator
 
 	return p
@@ -180,7 +180,7 @@ func (p *Provisioner) getParameters(ctx context.Context) ([]cd.HelmApplicationPa
 
 // getValues delegates to the generator to get an option values.yaml file to
 // pass to Helm.
-func (p *Provisioner) getValues(ctx context.Context) (interface{}, error) {
+func (p *Provisioner) getValues(ctx context.Context) (any, error) {
 	if p.generator == nil {
 		//nolint:nilnil
 		return nil, nil

--- a/pkg/provisioners/application/provisioner_test.go
+++ b/pkg/provisioners/application/provisioner_test.go
@@ -385,7 +385,7 @@ func (m *mutator) Parameters(ctx context.Context, version unikornv1.SemanticVers
 	return p, nil
 }
 
-func (m *mutator) Values(ctx context.Context, version unikornv1.SemanticVersion) (interface{}, error) {
+func (m *mutator) Values(ctx context.Context, version unikornv1.SemanticVersion) (any, error) {
 	return mutatorValues, nil
 }
 

--- a/pkg/provisioners/util/scheduling.go
+++ b/pkg/provisioners/util/scheduling.go
@@ -21,9 +21,9 @@ package util
 // have a pod scheduled on the control plane.  This is typically used
 // for managed services to keep them off the worker nodes and allow
 // scale to zero.
-func ControlPlaneTolerations() []interface{} {
-	return []interface{}{
-		map[string]interface{}{
+func ControlPlaneTolerations() []any {
+	return []any{
+		map[string]any{
 			"key":    "node-role.kubernetes.io/control-plane",
 			"effect": "NoSchedule",
 		},
@@ -33,8 +33,8 @@ func ControlPlaneTolerations() []interface{} {
 // ControlPlaneNodeSelector returns a key/value map of labels to match
 // in order to force scheduling on the control plane.  Used in conjunction
 // with, and for the same reason as, ControlPlaneTolerations.
-func ControlPlaneNodeSelector() map[string]interface{} {
-	return map[string]interface{}{
+func ControlPlaneNodeSelector() map[string]any {
+	return map[string]any{
 		"node-role.kubernetes.io/control-plane": "",
 	}
 }
@@ -43,14 +43,14 @@ func ControlPlaneNodeSelector() map[string]interface{} {
 // put in place, or are placed there by the system, on initial control plane
 // provisioning to ensure correct operation.  This is typically only for
 // things like the CNI and cloud provider.
-func ControlPlaneInitTolerations() []interface{} {
-	return []interface{}{
-		map[string]interface{}{
+func ControlPlaneInitTolerations() []any {
+	return []any{
+		map[string]any{
 			"key":    "node.cloudprovider.kubernetes.io/uninitialized",
 			"effect": "NoSchedule",
 			"value":  "true",
 		},
-		map[string]interface{}{
+		map[string]any{
 			"key":    "node.cilium.io/agent-not-ready",
 			"effect": "NoSchedule",
 			"value":  "true",

--- a/pkg/server/errors/errors.go
+++ b/pkg/server/errors/errors.go
@@ -79,7 +79,7 @@ type Error struct {
 	err error
 
 	// values are arbitrary key value pairs for logging.
-	values []interface{}
+	values []any
 }
 
 // newError returns a new HTTP error.
@@ -101,7 +101,7 @@ func (e *Error) WithError(err error) *Error {
 // WithValues augments the error with a set of K/V pairs.
 // Values should not use the "error" key as that's implicitly defined
 // by WithError and could collide.
-func (e *Error) WithValues(values ...interface{}) *Error {
+func (e *Error) WithValues(values ...any) *Error {
 	e.values = values
 
 	return e
@@ -124,7 +124,7 @@ func (e *Error) Write(w http.ResponseWriter, r *http.Request) {
 	// and return.
 	log := log.FromContext(r.Context())
 
-	var details []interface{}
+	var details []any
 
 	if e.description != "" {
 		details = append(details, "detail", e.description)

--- a/pkg/server/middleware/opentelemetry/opentelemetry.go
+++ b/pkg/server/middleware/opentelemetry/opentelemetry.go
@@ -38,8 +38,8 @@ import (
 )
 
 // logValuesFromSpan gets a generic set of key/value pairs from a span for logging.
-func logValuesFromSpanContext(name string, s trace.SpanContext) []interface{} {
-	return []interface{}{
+func logValuesFromSpanContext(name string, s trace.SpanContext) []any {
+	return []any{
 		"span.name", name,
 		"span.id", s.SpanID().String(),
 		"trace.id", s.TraceID().String(),
@@ -47,7 +47,7 @@ func logValuesFromSpanContext(name string, s trace.SpanContext) []interface{} {
 }
 
 // logValuesFromSpan gets a generic set of key/value pairs from a span for logging.
-func logValuesFromSpan(s sdktrace.ReadOnlySpan) []interface{} {
+func logValuesFromSpan(s sdktrace.ReadOnlySpan) []any {
 	values := logValuesFromSpanContext(s.Name(), s.SpanContext())
 
 	for _, attribute := range s.Attributes() {

--- a/pkg/server/util/json.go
+++ b/pkg/server/util/json.go
@@ -27,7 +27,7 @@ import (
 )
 
 // WriteJSONResponse is a generic wrapper for returning a JSON payload to the client.
-func WriteJSONResponse(w http.ResponseWriter, r *http.Request, code int, response interface{}) {
+func WriteJSONResponse(w http.ResponseWriter, r *http.Request, code int, response any) {
 	log := log.FromContext(r.Context())
 
 	body, err := json.Marshal(response)
@@ -47,7 +47,7 @@ func WriteJSONResponse(w http.ResponseWriter, r *http.Request, code int, respons
 }
 
 // ReadJSONBody is a generic request reader to unmarshal JSON bodies.
-func ReadJSONBody(r *http.Request, v interface{}) error {
+func ReadJSONBody(r *http.Request, v any) error {
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		return errors.OAuth2ServerError("unable to read request body").WithError(err)


### PR DESCRIPTION
This is clunky, for a long time now there has been the `any` type alias that can be used to increase code legibility.