### PR TITLE
Add Better Caching

### DIFF
--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -4,12 +4,12 @@ description: A Helm chart for deploying Unikorn Core
 
 type: application
 
-version: v0.1.95
-appVersion: v0.1.95
+version: v0.1.96-rc1
+appVersion: v0.1.96-rc1
 
 icon: https://assets.unikorn-cloud.org/images/logos/dark-on-light/icon.svg
 
 dependencies:
 - name: unikorn-common
-  version: v0.1.12
+  version: v0.1.15
   repository: https://unikorn-cloud.github.io/helm-common

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.24.2
 
 require (
 	github.com/Masterminds/semver/v3 v3.3.1
+	github.com/brunoga/deep v1.2.4
 	github.com/getkin/kin-openapi v0.131.0
 	github.com/go-logr/logr v1.4.2
 	github.com/go-openapi/jsonpointer v0.21.1

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/Masterminds/semver/v3 v3.3.1 h1:QtNSWtVZ3nBfk8mAOu/B6v7FMJ+NHTIgUPi7r
 github.com/Masterminds/semver/v3 v3.3.1/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/brunoga/deep v1.2.4 h1:Aj9E9oUbE+ccbyh35VC/NHlzzjfIVU69BXu2mt2LmL8=
+github.com/brunoga/deep v1.2.4/go.mod h1:GDV6dnXqn80ezsLSZ5Wlv1PdKAWAO4L5PnKYtv2dgaI=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/pkg/util/cache/lruexpirecache.go
+++ b/pkg/util/cache/lruexpirecache.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2025 the Unikorn Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"time"
+
+	"github.com/brunoga/deep"
+
+	"k8s.io/apimachinery/pkg/util/cache"
+)
+
+// LRUExpireCache is a drop in replacement for the apimachinery version
+// that makes it typed with generics, and also data immutable via deep
+// copies.
+type LRUExpireCache[K comparable, T any] struct {
+	cache *cache.LRUExpireCache
+}
+
+func NewLRUExpireCache[K comparable, T any](maxSize int) *LRUExpireCache[K, T] {
+	return &LRUExpireCache[K, T]{
+		cache: cache.NewLRUExpireCache(maxSize),
+	}
+}
+
+func (c *LRUExpireCache[K, T]) Add(key K, value T, ttl time.Duration) {
+	t, err := deep.Copy(value)
+	if err != nil {
+		return
+	}
+
+	c.cache.Add(key, t, ttl)
+}
+
+func (c *LRUExpireCache[K, T]) Get(key K) (T, bool) {
+	var zero T
+
+	value, ok := c.cache.Get(key)
+	if !ok {
+		return zero, false
+	}
+
+	typedValue, ok := value.(T)
+	if !ok {
+		return zero, false
+	}
+
+	t, err := deep.Copy(typedValue)
+	if err != nil {
+		return zero, false
+	}
+
+	return t, true
+}


### PR DESCRIPTION
Uses apimachinery's cache to make it a bounded key-value store.  It's still not perfect as it lacks type safety, and also may lead to memory corruption, so add those features.