### PR TITLE
Expand Reference Handler Library

### DIFF
--- a/pkg/manager/reconcile.go
+++ b/pkg/manager/reconcile.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"slices"
 
 	unikornv1 "github.com/unikorn-cloud/core/pkg/apis/unikorn/v1alpha1"
 	"github.com/unikorn-cloud/core/pkg/cd"
@@ -161,16 +160,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	log.Info("reconciling object")
 
 	return r.reconcileNormal(ctx, provisioner, object)
-}
-
-// hasExternalReferences tells us if we have any external finalizers on our object
-// above and beyond the default one.
-func hasExternalReferences(object unikornv1.ManagableResourceInterface) bool {
-	discard := func(s string) bool {
-		return s == constants.Finalizer
-	}
-
-	return len(slices.DeleteFunc(slices.Clone(object.GetFinalizers()), discard)) != 0
 }
 
 // reconcileDelete handles object deletion.

--- a/pkg/manager/reference_test.go
+++ b/pkg/manager/reference_test.go
@@ -21,13 +21,16 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/unikorn-cloud/core/pkg/constants"
 	"github.com/unikorn-cloud/core/pkg/manager"
 
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -54,7 +57,146 @@ func TestReferenceGeneration(t *testing.T) {
 		},
 	}
 
-	reference, err := manager.GetResourceReference(client, object)
+	reference, err := manager.GenerateResourceReference(client, object)
 	require.NoError(t, err)
 	require.Equal(t, "ingresses.networking.k8s.io/foo", reference)
+}
+
+// TestRererenceRead tests reference reads work correctly, in particular the
+// filtering out of any well-known non-reference finalizers, but also ensuring
+// the operation treats the underlying object as immutable (slices.Delete does
+// things you may not expect to the underlying array of a slice...)
+func TestRererenceRead(t *testing.T) {
+	t.Parallel()
+
+	reference1 := "cat"
+	reference2 := "dag"
+
+	object := &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+			Finalizers: []string{
+				constants.Finalizer,
+				reference1,
+				reference2,
+			},
+		},
+	}
+
+	references := manager.GetResourceReferences(object)
+	require.Len(t, references, 2)
+	require.Contains(t, references, reference1)
+	require.Contains(t, references, reference2)
+
+	require.Len(t, object.Finalizers, 3)
+	require.Contains(t, object.Finalizers, constants.Finalizer)
+	require.Contains(t, object.Finalizers, reference1)
+	require.Contains(t, object.Finalizers, reference2)
+}
+
+// TestReferenceClear tests references can be cleared in bulk from a collection
+// of resources.
+func TestReferenceClear(t *testing.T) {
+	t.Parallel()
+
+	reference := "cat"
+	label := "animal"
+	labelValue1 := "giraffe"
+	labelValue2 := "elephant"
+	namespace1 := "donkey"
+	namespace2 := "dragon"
+
+	objects := &networkingv1.IngressList{
+		Items: []networkingv1.Ingress{
+			// Reference removed, finalizer intact.
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace1,
+					Name:      "foo",
+					Labels: map[string]string{
+						label: labelValue1,
+					},
+					Finalizers: []string{
+						constants.Finalizer,
+						reference,
+					},
+				},
+			},
+			// Nothing happens and it doesn't crash.
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace1,
+					Name:      "bar",
+					Labels: map[string]string{
+						label: labelValue1,
+					},
+				},
+			},
+			// Unaffected as part of a different selection.
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace1,
+					Name:      "baz",
+					Labels: map[string]string{
+						label: labelValue2,
+					},
+					Finalizers: []string{
+						constants.Finalizer,
+						reference,
+					},
+				},
+			},
+			// Unaffected as part of a different namespace.
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace2,
+					Name:      "baz",
+					Labels: map[string]string{
+						label: labelValue2,
+					},
+					Finalizers: []string{
+						constants.Finalizer,
+						reference,
+					},
+				},
+			},
+		},
+	}
+
+	o := []client.Object{
+		&objects.Items[0],
+		&objects.Items[1],
+		&objects.Items[2],
+		&objects.Items[3],
+	}
+
+	cli := fake.NewClientBuilder().WithObjects(o...).Build()
+
+	options := &client.ListOptions{
+		Namespace: namespace1,
+		LabelSelector: labels.SelectorFromSet(map[string]string{
+			label: labelValue1,
+		}),
+	}
+
+	require.NoError(t, manager.ClearResourceReferences(t.Context(), cli, &networkingv1.IngressList{}, options, reference))
+
+	object := &networkingv1.Ingress{}
+
+	require.NoError(t, cli.Get(t.Context(), client.ObjectKey{Namespace: namespace1, Name: "foo"}, object))
+	require.Len(t, object.Finalizers, 1)
+	require.Contains(t, object.Finalizers, constants.Finalizer)
+
+	require.NoError(t, cli.Get(t.Context(), client.ObjectKey{Namespace: namespace1, Name: "bar"}, object))
+	require.Len(t, object.Finalizers, 0)
+
+	require.NoError(t, cli.Get(t.Context(), client.ObjectKey{Namespace: namespace1, Name: "baz"}, object))
+	require.Len(t, object.Finalizers, 2)
+	require.Contains(t, object.Finalizers, constants.Finalizer)
+	require.Contains(t, object.Finalizers, reference)
+
+	require.NoError(t, cli.Get(t.Context(), client.ObjectKey{Namespace: namespace2, Name: "baz"}, object))
+	require.Len(t, object.Finalizers, 2)
+	require.Contains(t, object.Finalizers, constants.Finalizer)
+	require.Contains(t, object.Finalizers, reference)
 }


### PR DESCRIPTION
Adds in an exported function so you can extract the list of references on an object, handy to expose to the user what's using what and either warn what will happen on deletion or inhibit it all together.  Adds in a cleanup function, backed by some tests.