### PR TITLE
Clean Up Reconciler

### DIFF
--- a/pkg/manager/reconcile_test.go
+++ b/pkg/manager/reconcile_test.go
@@ -503,7 +503,7 @@ func TestReconcileDeleteCancelled(t *testing.T) {
 	reconciler := manager.NewReconciler(managerOptions(), nil, tc.newManager(c), func(_ manager.ControllerOptions) provisioners.ManagerProvisioner { return p })
 
 	_, err := reconciler.Reconcile(ctx, newRequest(testNamespace, testName))
-	assert.NoError(t, err)
+	assert.Error(t, err)
 
 	// Does the resource still exist in Kubernetes?
 	var result unikornv1fake.ManagedResource
@@ -544,7 +544,7 @@ func TestReconcileDeleteError(t *testing.T) {
 	reconciler := manager.NewReconciler(managerOptions(), nil, tc.newManager(c), func(_ manager.ControllerOptions) provisioners.ManagerProvisioner { return p })
 
 	_, err := reconciler.Reconcile(ctx, newRequest(testNamespace, testName))
-	assert.NoError(t, err)
+	assert.Error(t, err)
 
 	// Does the resource still exist in Kubernetes?
 	var result unikornv1fake.ManagedResource


### PR DESCRIPTION
Makes resource update errors less forceful, it's a natural thing with multiple controllers poking the same object.  The error raisng semantics have been updated to convery true, unhandled, errors though.