### PR TITLE
Make Provisioner Logging Less Chatty

### DIFF
--- a/pkg/cd/argocd/driver.go
+++ b/pkg/cd/argocd/driver.go
@@ -372,7 +372,7 @@ func (d *Driver) CreateOrUpdateHelmApplication(ctx context.Context, id *cd.Resou
 
 		resource = required
 	} else {
-		log.Info("updating existing application", "application", id.Name)
+		log.V(1).Info("updating existing application", "application", id.Name)
 
 		// Replace the specification with what we expect.
 		temp := resource.DeepCopy()
@@ -435,7 +435,7 @@ func (d *Driver) DeleteHelmApplication(ctx context.Context, id *cd.ResourceIdent
 		return provisioners.ErrYield
 	}
 
-	log.Info("adding application finalizer", "application", id.Name)
+	log.V(1).Info("adding application finalizer", "application", id.Name)
 
 	// Apply a finalizer to ensure synchronous deletion. See
 	// https://argo-cd.readthedocs.io/en/stable/user-guide/app_deletion/
@@ -450,7 +450,7 @@ func (d *Driver) DeleteHelmApplication(ctx context.Context, id *cd.ResourceIdent
 		return err
 	}
 
-	log.Info("deleting application", "application", id.Name)
+	log.V(1).Info("deleting application", "application", id.Name)
 
 	if err := d.client.Delete(ctx, resource); err != nil {
 		return err
@@ -569,7 +569,7 @@ func (d *Driver) CreateOrUpdateCluster(ctx context.Context, id *cd.ResourceIdent
 			return err
 		}
 
-		log.Info("awaiting cluster connectivity")
+		log.V(1).Info("awaiting cluster connectivity")
 
 		tester := d.options.K8SAPITester
 
@@ -582,7 +582,7 @@ func (d *Driver) CreateOrUpdateCluster(ctx context.Context, id *cd.ResourceIdent
 				return err
 			}
 
-			log.Info("failed to get kubernetes service")
+			log.Info("failed to connect to kubernetes service")
 
 			return provisioners.ErrYield
 		}
@@ -620,16 +620,16 @@ func (d *Driver) CreateOrUpdateCluster(ctx context.Context, id *cd.ResourceIdent
 		"config": configData,
 	}
 
-	log.Info("reconciling cluster", "id", id)
+	log.V(1).Info("reconciling cluster", "id", id)
 
 	result, err := controllerutil.CreateOrPatch(ctx, d.client, current, mustateSecret(current, labels, data))
 	if err != nil {
-		log.Info("cluster reconcile failed", "error", err)
+		log.V(1).Info("cluster reconcile failed", "error", err)
 
 		return err
 	}
 
-	log.Info("cluster reconciled", "id", id, "result", result)
+	log.V(1).Info("cluster reconciled", "id", id, "result", result)
 
 	return nil
 }

--- a/pkg/provisioners/concurrent/provisioner.go
+++ b/pkg/provisioners/concurrent/provisioner.go
@@ -48,10 +48,12 @@ func New(name string, p ...provisioners.Provisioner) *Provisioner {
 var _ provisioners.Provisioner = &Provisioner{}
 
 // Provision implements the Provision interface.
+//
+//nolint:dupl
 func (p *Provisioner) Provision(ctx context.Context) error {
 	log := log.FromContext(ctx)
 
-	log.Info("provisioning concurrency group", "group", p.Name)
+	log.V(1).Info("provisioning concurrency group", "group", p.Name)
 
 	group := &errgroup.Group{}
 
@@ -63,7 +65,7 @@ func (p *Provisioner) Provision(ctx context.Context) error {
 			// logging information, so do this here when waiting on child
 			// tasks.
 			if err := provisioner.Provision(ctx); err != nil {
-				log.Info("concurrency group member exited with error", "error", err, "group", p.Name, "provisioner", provisioner.ProvisionerName())
+				log.V(1).Info("concurrency group member exited with error", "error", err, "group", p.Name, "provisioner", provisioner.ProvisionerName())
 
 				return err
 			}
@@ -75,21 +77,23 @@ func (p *Provisioner) Provision(ctx context.Context) error {
 	}
 
 	if err := group.Wait(); err != nil {
-		log.Info("concurrency group provision failed", "group", p.Name)
+		log.V(1).Info("concurrency group provision failed", "group", p.Name)
 
 		return err
 	}
 
-	log.Info("concurrency group provisioned", "group", p.Name)
+	log.V(1).Info("concurrency group provisioned", "group", p.Name)
 
 	return nil
 }
 
 // Deprovision implements the Provision interface.
+//
+//nolint:dupl
 func (p *Provisioner) Deprovision(ctx context.Context) error {
 	log := log.FromContext(ctx)
 
-	log.Info("deprovisioning concurrency group", "group", p.Name)
+	log.V(1).Info("deprovisioning concurrency group", "group", p.Name)
 
 	group := &errgroup.Group{}
 
@@ -101,7 +105,7 @@ func (p *Provisioner) Deprovision(ctx context.Context) error {
 			// logging information, so do this here when waiting on child
 			// tasks.
 			if err := provisioner.Deprovision(ctx); err != nil {
-				log.Info("concurrency group member exited with error", "error", err, "group", p.Name, "provisioner", provisioner.ProvisionerName())
+				log.V(1).Info("concurrency group member exited with error", "error", err, "group", p.Name, "provisioner", provisioner.ProvisionerName())
 
 				return err
 			}
@@ -113,12 +117,12 @@ func (p *Provisioner) Deprovision(ctx context.Context) error {
 	}
 
 	if err := group.Wait(); err != nil {
-		log.Info("concurrency group deprovision failed", "group", p.Name)
+		log.V(1).Info("concurrency group deprovision failed", "group", p.Name)
 
 		return err
 	}
 
-	log.Info("concurrency group deprovisioned", "group", p.Name)
+	log.V(1).Info("concurrency group deprovisioned", "group", p.Name)
 
 	return nil
 }

--- a/pkg/provisioners/conditional/provisioner.go
+++ b/pkg/provisioners/conditional/provisioner.go
@@ -53,7 +53,7 @@ func (p *Provisioner) Provision(ctx context.Context) error {
 	log := log.FromContext(ctx)
 
 	if !p.condition() {
-		log.Info("conditional deprovision", "provisioner", p.Name)
+		log.V(1).Info("conditional deprovision", "provisioner", p.Name)
 
 		return p.provisioner.Deprovision(ctx)
 	}

--- a/pkg/provisioners/remotecluster/provisioner.go
+++ b/pkg/provisioners/remotecluster/provisioner.go
@@ -165,7 +165,7 @@ func (p *remoteClusterProvisioner) provisionRemote(ctx context.Context) error {
 
 	// If this is the first remote cluster encountered, reconcile it.
 	if p.remote.controller && p.remote.currentCount == 1 {
-		log.Info("provisioning remote cluster", "remotecluster", id)
+		log.V(1).Info("provisioning remote cluster", "remotecluster", id)
 
 		config, err := p.remote.generator.Config(ctx)
 		if err != nil {
@@ -178,12 +178,12 @@ func (p *remoteClusterProvisioner) provisionRemote(ctx context.Context) error {
 		}
 
 		if err := cd.FromContext(ctx).CreateOrUpdateCluster(ctx, id, cluster); err != nil {
-			log.Info("remote cluster not ready, yielding", "remotecluster", id)
+			log.V(1).Info("remote cluster not ready, yielding", "remotecluster", id)
 
 			return provisioners.ErrYield
 		}
 
-		log.Info("remote cluster provisioned", "remotecluster", id)
+		log.V(1).Info("remote cluster provisioned", "remotecluster", id)
 	}
 
 	return nil
@@ -311,13 +311,13 @@ func (p *remoteClusterProvisioner) Deprovision(ctx context.Context) error {
 	// ... and if all have completed without an error, then deprovision the
 	// remote cluster itself.
 	if p.remote.controller && p.remote.currentCount == p.remote.refCount {
-		log.Info("deprovisioning remote cluster", "remotecluster", id)
+		log.V(1).Info("deprovisioning remote cluster", "remotecluster", id)
 
 		if err := cd.FromContext(ctx).DeleteCluster(ctx, id); err != nil {
 			return err
 		}
 
-		log.Info("remote cluster deprovisioned", "remotecluster", id)
+		log.V(1).Info("remote cluster deprovisioned", "remotecluster", id)
 	}
 
 	return nil

--- a/pkg/provisioners/resource/resource.go
+++ b/pkg/provisioners/resource/resource.go
@@ -67,14 +67,14 @@ func (p *Provisioner) Provision(ctx context.Context) error {
 
 	objectKey := client.ObjectKeyFromObject(p.resource)
 
-	log.Info("creating object", "key", objectKey)
+	log.V(1).Info("creating object", "key", objectKey)
 
 	result, err := controllerutil.CreateOrUpdate(ctx, clusterContext.Client, p.resource, mutate)
 	if err != nil {
 		return err
 	}
 
-	log.Info(fmt.Sprintf("object %v", result), "name", p.resource.GetName(), "generateName", p.resource.GetGenerateName())
+	log.V(1).Info(fmt.Sprintf("object %v", result), "name", p.resource.GetName(), "generateName", p.resource.GetGenerateName())
 
 	return nil
 }
@@ -90,11 +90,11 @@ func (p *Provisioner) Deprovision(ctx context.Context) error {
 
 	objectKey := client.ObjectKeyFromObject(p.resource)
 
-	log.Info("deleting object", "key", objectKey)
+	log.V(1).Info("deleting object", "key", objectKey)
 
 	if err := clusterContext.Client.Delete(ctx, p.resource); err != nil {
 		if errors.IsNotFound(err) {
-			log.Info("object deleted", "key", objectKey)
+			log.V(1).Info("object deleted", "key", objectKey)
 
 			return nil
 		}
@@ -102,7 +102,7 @@ func (p *Provisioner) Deprovision(ctx context.Context) error {
 		return err
 	}
 
-	log.Info("awaiting object deletion", "key", objectKey)
+	log.V(1).Info("awaiting object deletion", "key", objectKey)
 
 	return provisioners.ErrYield
 }

--- a/pkg/provisioners/serial/provisioner.go
+++ b/pkg/provisioners/serial/provisioner.go
@@ -48,17 +48,17 @@ var _ provisioners.Provisioner = &Provisioner{}
 func (p *Provisioner) Provision(ctx context.Context) error {
 	log := log.FromContext(ctx)
 
-	log.Info("provisioning serial group", "group", p.Name)
+	log.V(1).Info("provisioning serial group", "group", p.Name)
 
 	for _, provisioner := range p.provisioners {
 		if err := provisioner.Provision(ctx); err != nil {
-			log.Info("serial group member exited with error", "error", err, "group", p.Name, "provisioner", provisioner.ProvisionerName())
+			log.V(1).Info("serial group member exited with error", "error", err, "group", p.Name, "provisioner", provisioner.ProvisionerName())
 
 			return err
 		}
 	}
 
-	log.Info("serial group provisioned", "group", p.Name)
+	log.V(1).Info("serial group provisioned", "group", p.Name)
 
 	return nil
 }
@@ -70,19 +70,19 @@ func (p *Provisioner) Provision(ctx context.Context) error {
 func (p *Provisioner) Deprovision(ctx context.Context) error {
 	log := log.FromContext(ctx)
 
-	log.Info("deprovisioning serial group", "group", p.Name)
+	log.V(1).Info("deprovisioning serial group", "group", p.Name)
 
 	for i := range p.provisioners {
 		provisioner := p.provisioners[len(p.provisioners)-(i+1)]
 
 		if err := provisioner.Deprovision(ctx); err != nil {
-			log.Info("serial group member exited with error", "error", err, "group", p.Name, "provisioner", provisioner.ProvisionerName())
+			log.V(1).Info("serial group member exited with error", "error", err, "group", p.Name, "provisioner", provisioner.ProvisionerName())
 
 			return err
 		}
 	}
 
-	log.Info("serial group deprovisioned", "group", p.Name)
+	log.V(1).Info("serial group deprovisioned", "group", p.Name)
 
 	return nil
 }


### PR DESCRIPTION
Looking back at Kubernetes cluster provisioning in particular, it's very very chatty, to the point that you cannot really see what is happening on the CLI.  We should reduce 90% of log output to a higher verbosity level, leaving on the the pertinent things like, I've created an application, I'm waiting for connectivity, I'm waiting for an application to provision etc.