### PR TITLE
Reload TLS client certificates inline from the Kubernetes cache

### DIFF
--- a/pkg/client/http.go
+++ b/pkg/client/http.go
@@ -24,6 +24,8 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
+	"sync"
+	"time"
 
 	jose "github.com/go-jose/go-jose/v4"
 	"github.com/spf13/pflag"
@@ -34,6 +36,8 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+const defaultClientCertificateReloadInterval = 24 * time.Hour
 
 // HTTPOptions are generic options for HTTP clients.
 type HTTPOptions struct {
@@ -102,12 +106,103 @@ type HTTPClientOptions struct {
 	secretNamespace string
 	// secretName is the client certificate for the service.
 	secretName string
+	// reloadInterval determines how often the client certificate is reloaded.
+	reloadInterval time.Duration
+	now            func() time.Time
 }
 
 // AddFlags adds the options to the CLI flags.
 func (o *HTTPClientOptions) AddFlags(f *pflag.FlagSet) {
 	f.StringVar(&o.secretNamespace, "client-certificate-namespace", o.secretNamespace, "Client certificate secret namespace.")
 	f.StringVar(&o.secretName, "client-certificate-name", o.secretName, "Client certificate secret name.")
+	f.DurationVar(&o.reloadInterval, "client-certificate-reload-interval", defaultClientCertificateReloadInterval, "How often to check for a rotated client certificate. Zero or negative disables periodic reload.")
+}
+
+// SetNow overrides the clock used for inline client certificate reload checks.
+func (o *HTTPClientOptions) SetNow(now func() time.Time) {
+	o.now = now
+}
+
+func (o *HTTPClientOptions) clock() func() time.Time {
+	if o.now != nil {
+		return o.now
+	}
+
+	return time.Now
+}
+
+type tlsClientCertificateSource struct {
+	mu sync.Mutex
+	// current is the last successfully loaded certificate and is retained across reload failures.
+	current *tls.Certificate
+	// nextCheck bounds reload attempts to avoid reloading on every handshake.
+	nextCheck      time.Time
+	reloadInterval time.Duration
+	now            func() time.Time
+	loader         func() (*tls.Certificate, error)
+}
+
+type tlsClientCertificateReloader struct {
+	options *HTTPClientOptions
+	client  client.Client
+}
+
+func (r *tlsClientCertificateReloader) Load() (*tls.Certificate, error) {
+	// Reloads happen on future TLS handshakes, so reusing the setup context would make
+	// certificate refresh depend on whatever timeout/cancellation policy existed when
+	// the transport was constructed. A background context keeps reloads independent of
+	// that one-shot setup path. The tradeoff is that reloads are not currently time-bounded.
+	return r.options.loadTLSCertificate(context.Background(), r.client)
+}
+
+func newTLSClientCertificateSource(reloadInterval time.Duration, now func() time.Time, loader func() (*tls.Certificate, error)) (*tlsClientCertificateSource, error) {
+	certificate, err := loader()
+	if err != nil {
+		return nil, err
+	}
+
+	source := &tlsClientCertificateSource{
+		current:        certificate,
+		reloadInterval: reloadInterval,
+		now:            now,
+		loader:         loader,
+	}
+
+	if reloadInterval > 0 {
+		source.nextCheck = now().Add(reloadInterval)
+	}
+
+	return source, nil
+}
+
+func (s *tlsClientCertificateSource) GetClientCertificate(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.reloadInterval <= 0 {
+		return s.current, nil
+	}
+
+	if s.now().Before(s.nextCheck) {
+		return s.current, nil
+	}
+
+	// Reload inline when the next handshake notices the check window has elapsed.
+	certificate, err := s.loader()
+	if err != nil {
+		if s.current != nil {
+			return s.current, nil
+		}
+
+		// The source preloads a certificate during construction, so this is a defensive
+		// fallback for completeness rather than an expected runtime path.
+		return nil, err
+	}
+
+	s.current = certificate
+	s.nextCheck = s.now().Add(s.reloadInterval)
+
+	return s.current, nil
 }
 
 func (o *HTTPClientOptions) loadTLSCertificate(ctx context.Context, cli client.Client) (*tls.Certificate, error) {
@@ -128,7 +223,7 @@ func (o *HTTPClientOptions) loadTLSCertificate(ctx context.Context, cli client.C
 
 	key, ok := secret.Data[corev1.TLSPrivateKeyKey]
 	if !ok {
-		return nil, fmt.Errorf("%w: certifcate missing tls.key", errors.ErrSecretFormatError)
+		return nil, fmt.Errorf("%w: certificate missing tls.key", errors.ErrSecretFormatError)
 	}
 
 	certificate, err := tls.X509KeyPair(cert, key)
@@ -146,14 +241,18 @@ func (o *HTTPClientOptions) ApplyTLSClientConfig(ctx context.Context, cli client
 		return nil
 	}
 
-	certificate, err := o.loadTLSCertificate(ctx, cli)
+	reloader := &tlsClientCertificateReloader{
+		options: o,
+		client:  cli,
+	}
+
+	// Reloads happen during future TLS handshakes, so they must not depend on the setup context.
+	source, err := newTLSClientCertificateSource(o.reloadInterval, o.clock(), reloader.Load)
 	if err != nil {
 		return err
 	}
 
-	config.Certificates = []tls.Certificate{
-		*certificate,
-	}
+	config.GetClientCertificate = source.GetClientCertificate
 
 	return nil
 }

--- a/pkg/client/http_test.go
+++ b/pkg/client/http_test.go
@@ -1,0 +1,346 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client_test
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"io"
+	"math/big"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
+
+	coreclient "github.com/unikorn-cloud/core/pkg/client"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+type countingClient struct {
+	crclient.Client
+
+	gets       atomic.Int32
+	blockOnGet int32
+	getStarted chan struct{}
+	releaseGet chan struct{}
+	signalOnce sync.Once
+}
+
+func (c *countingClient) Get(ctx context.Context, key crclient.ObjectKey, obj crclient.Object, opts ...crclient.GetOption) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	count := c.gets.Add(1)
+
+	if c.blockOnGet > 0 && count == c.blockOnGet {
+		c.signalOnce.Do(func() {
+			close(c.getStarted)
+		})
+
+		<-c.releaseGet
+	}
+
+	return c.Client.Get(ctx, key, obj, opts...)
+}
+
+func (c *countingClient) GetCount() int {
+	return int(c.gets.Load())
+}
+
+type staticClock struct {
+	current time.Time
+}
+
+func newStaticClock() *staticClock {
+	return &staticClock{current: time.Now()}
+}
+
+func (c *staticClock) Now() time.Time {
+	return c.current
+}
+
+func (c *staticClock) Advance(d time.Duration) {
+	c.current = c.current.Add(d)
+}
+
+func TestApplyTLSClientConfigUsesGetClientCertificate(t *testing.T) {
+	t.Parallel()
+
+	clock := newStaticClock()
+	config, client := mustTLSClientConfig(t, clock, time.Hour, mustTLSSecret(t, 1))
+
+	require.Nil(t, config.Certificates)
+	require.NotNil(t, config.GetClientCertificate)
+	require.Equal(t, 1, client.GetCount())
+
+	certificate, err := config.GetClientCertificate(nil)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, serialNumber(t, certificate))
+	require.Equal(t, 1, client.GetCount())
+}
+
+func TestApplyTLSClientConfigReloadsWhenDue(t *testing.T) {
+	t.Parallel()
+
+	clock := newStaticClock()
+	config, client := mustTLSClientConfig(t, clock, time.Hour, mustTLSSecret(t, 1))
+
+	require.NoError(t, updateSecret(t, client.Client, mustTLSSecret(t, 2)))
+	clock.Advance(time.Hour + time.Minute)
+
+	certificate, err := config.GetClientCertificate(nil)
+	require.NoError(t, err)
+	require.EqualValues(t, 2, serialNumber(t, certificate))
+	require.Equal(t, 2, client.GetCount())
+}
+
+func TestApplyTLSClientConfigReloadFailurePreservesCurrent(t *testing.T) {
+	t.Parallel()
+
+	clock := newStaticClock()
+	config, client := mustTLSClientConfig(t, clock, time.Hour, mustTLSSecret(t, 1))
+
+	require.NoError(t, client.Delete(t.Context(), secretStub("client-cert")))
+	clock.Advance(time.Hour + time.Minute)
+
+	certificate, err := config.GetClientCertificate(nil)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, serialNumber(t, certificate))
+	require.Equal(t, 2, client.GetCount())
+}
+
+func TestApplyTLSClientConfigDisabledReloadKeepsCachedCertificate(t *testing.T) {
+	t.Parallel()
+
+	clock := newStaticClock()
+	config, client := mustTLSClientConfig(t, clock, 0, mustTLSSecret(t, 1))
+
+	require.NoError(t, updateSecret(t, client.Client, mustTLSSecret(t, 2)))
+	clock.Advance(24 * time.Hour)
+
+	certificate, err := config.GetClientCertificate(nil)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, serialNumber(t, certificate))
+	require.Equal(t, 1, client.GetCount())
+}
+
+func TestApplyTLSClientConfigConcurrentReloadIsSerialized(t *testing.T) {
+	t.Parallel()
+
+	clock := newStaticClock()
+	config, client := mustTLSClientConfig(t, clock, time.Hour, mustTLSSecret(t, 1))
+	client.blockOnGet = 2
+	client.getStarted = make(chan struct{})
+	client.releaseGet = make(chan struct{})
+
+	require.NoError(t, updateSecret(t, client.Client, mustTLSSecret(t, 2)))
+	clock.Advance(time.Hour + time.Minute)
+
+	var wg sync.WaitGroup
+
+	results := make(chan int64, 8)
+	errs := make(chan error, 8)
+
+	for range 8 {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			certificate, err := config.GetClientCertificate(nil)
+			if err != nil {
+				errs <- err
+				return
+			}
+
+			results <- serialNumber(t, certificate)
+		}()
+	}
+
+	<-client.getStarted
+	close(client.releaseGet)
+	wg.Wait()
+	close(results)
+	close(errs)
+
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	for serial := range results {
+		require.EqualValues(t, 2, serial)
+	}
+
+	require.Equal(t, 2, client.GetCount())
+}
+
+func TestApplyTLSClientConfigInitialLoadFailure(t *testing.T) {
+	t.Parallel()
+
+	clock := newStaticClock()
+	scheme, err := coreclient.NewScheme()
+	require.NoError(t, err)
+
+	client := &countingClient{
+		Client: fake.NewClientBuilder().WithScheme(scheme).Build(),
+	}
+	options := &coreclient.HTTPClientOptions{}
+
+	flags := pflagSet(t, options)
+	require.NoError(t, flags.Parse([]string{
+		"--client-certificate-namespace=test",
+		"--client-certificate-name=client-cert",
+		"--client-certificate-reload-interval=1h",
+	}))
+	options.SetNow(clock.Now)
+
+	config := &tls.Config{MinVersion: tls.VersionTLS13}
+
+	err = options.ApplyTLSClientConfig(t.Context(), client, config)
+	require.Error(t, err)
+	require.Nil(t, config.GetClientCertificate)
+	require.Equal(t, 1, client.GetCount())
+}
+
+func mustTLSClientConfig(t *testing.T, clock *staticClock, reloadInterval time.Duration, secret *corev1.Secret) (*tls.Config, *countingClient) {
+	t.Helper()
+
+	scheme, err := coreclient.NewScheme()
+	require.NoError(t, err)
+
+	baseClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
+	client := &countingClient{Client: baseClient}
+	options := &coreclient.HTTPClientOptions{}
+
+	flags := pflagSet(t, options)
+	require.NoError(t, flags.Parse([]string{
+		"--client-certificate-namespace=test",
+		"--client-certificate-name=client-cert",
+		"--client-certificate-reload-interval=" + reloadInterval.String(),
+	}))
+	options.SetNow(clock.Now)
+
+	config := &tls.Config{MinVersion: tls.VersionTLS13}
+
+	err = options.ApplyTLSClientConfig(t.Context(), client, config)
+	require.NoError(t, err)
+
+	return config, client
+}
+
+func pflagSet(t *testing.T, options *coreclient.HTTPClientOptions) *pflag.FlagSet {
+	t.Helper()
+
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	flags.SetOutput(io.Discard)
+	options.AddFlags(flags)
+
+	return flags
+}
+
+func updateSecret(t *testing.T, client crclient.Client, secret *corev1.Secret) error {
+	t.Helper()
+
+	current := &corev1.Secret{}
+	key := crclient.ObjectKeyFromObject(secret)
+
+	if err := client.Get(t.Context(), key, current); err != nil {
+		return err
+	}
+
+	current.Type = secret.Type
+	current.Data = secret.Data
+
+	return client.Update(t.Context(), current)
+}
+
+func secretStub(name string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "test",
+			Name:      name,
+		},
+	}
+}
+
+func mustTLSSecret(t *testing.T, serial int64) *corev1.Secret {
+	t.Helper()
+
+	certPEM, keyPEM := mustIssueTLSKeyPair(t, serial)
+
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "test",
+			Name:      "client-cert",
+		},
+		Type: corev1.SecretTypeTLS,
+		Data: map[string][]byte{
+			corev1.TLSCertKey:       certPEM,
+			corev1.TLSPrivateKeyKey: keyPEM,
+		},
+	}
+}
+
+func mustIssueTLSKeyPair(t *testing.T, serial int64) ([]byte, []byte) {
+	t.Helper()
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(serial),
+		Subject: pkix.Name{
+			CommonName: "client",
+		},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		BasicConstraintsValid: true,
+	}
+
+	certificateDER, err := x509.CreateCertificate(rand.Reader, template, template, &privateKey.PublicKey, privateKey)
+	require.NoError(t, err)
+
+	certificatePEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certificateDER})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(privateKey)})
+
+	return certificatePEM, keyPEM
+}
+
+func serialNumber(t *testing.T, certificate *tls.Certificate) int64 {
+	t.Helper()
+
+	leaf, err := x509.ParseCertificate(certificate.Certificate[0])
+	require.NoError(t, err)
+
+	return leaf.SerialNumber.Int64()
+}


### PR DESCRIPTION
Replace the static tls.Config.Certificates assignment with a GetClientCertificate callback so long-lived HTTP transports keep connection pooling while new TLS handshakes can pick up rotated client certificates.

The reload path stays intentionally simple: preload once during TLS config setup, keep the last successfully loaded certificate in memory, and use a mutex-serialized inline reload when the configured reload interval elapses. Zero or negative reload intervals disable periodic reload and retain the current post-startup behaviour.

On reload failure the previous in-memory certificate is preserved, which bounds failures to reload lag or cache/secret problems instead of permanent process staleness. The tests are deterministic and clock-driven rather than sleep-based, including coverage for cached reads, due reloads, failure retention, disabled reloads and serialized concurrent reloads.

This change only addresses client certificate rotation. CA RootCAs loading remains static by design here because the issuer CA is currently long-lived.
