### PR TITLE
cache: add write-through overlay support

### DIFF
--- a/pkg/util/cache/refresh_ahead.go
+++ b/pkg/util/cache/refresh_ahead.go
@@ -47,6 +47,11 @@ type Epoch struct {
 	epoch uint64
 }
 
+// after checks whether e represents a later revision than other.
+func (e Epoch) after(other Epoch) bool {
+	return e.epoch > other.epoch
+}
+
 // Valid checks if a previous epoch is still valid against the current one.
 func (e Epoch) Valid(previous Epoch) bool {
 	return e.epoch == previous.epoch
@@ -85,7 +90,7 @@ type ListSnapshot[T any] struct {
 	Epoch Epoch
 	// Items are the individual cache items.  No ordering constraints are placed
 	// on the snapshot items as this is likely to be more efficient downstream
-	// after any potential filtering oprtations.
+	// after any potential filtering operations.
 	Items []*T
 }
 
@@ -137,6 +142,16 @@ func (m cacheMap[T, TP]) Equal(o cacheMap[T, TP]) bool {
 	return true
 }
 
+// overlayEntry records a local mutation that must remain visible until a later
+// refresh that started after the mutation has completed.
+type overlayEntry[T any, TP CacheablePointer[T]] struct {
+	item  TP
+	epoch Epoch
+}
+
+// overlayMap records pending local mutations by cache key.
+type overlayMap[T any, TP CacheablePointer[T]] map[string]overlayEntry[T, TP]
+
 // invalidationRequest allows a client to synchronously trigger
 // a cache invalidation.
 type invalidationRequest struct {
@@ -165,9 +180,37 @@ type invalidationRequest struct {
 // example on creation or update to avoid having to perform a potentially
 // costly rebuild.
 //
+// Local writes are applied through a write-through overlay. A local mutation
+// is immediately visible in the effective cache view. If a refresh is already
+// in flight when that mutation happens, the overlay survives that refresh so
+// the stale backend snapshot cannot erase the new value.
+//
+// Correctness depends on two usage constraints:
+//   - This is a single-instance cache. If callers write through one process and
+//     read through another cache instance, read-your-writes is not guaranteed.
+//   - InsertIfAbsent and Upsert must only be called after the corresponding
+//     backend write has synchronously and atomically committed. A refresh that
+//     starts after such a write is assumed to observe that committed state.
+//
+// Once a later refresh starts after the mutation, the backend snapshot is
+// treated as authoritative again and the overlay entry is discarded. In other
+// words, the overlay only bridges writes that land during an in-flight
+// refresh; it is not a long-lived reconciliation layer.
+//
+// This model has primarily been designed and tested for singleton-style writes,
+// for example creates keyed by a unique primary key where only one object can
+// exist for that key.
+//
+// For a single cache instance, concurrent calls to InsertIfAbsent and Upsert
+// are serialized by the cache lock. However, if multiple writers concurrently
+// commit different values for the same key in the backend, the cache does not
+// try to apply any extra heuristic to pick a local winner beyond that
+// serialization order. In that case the visible value will still converge back
+// to the backend on the next authoritative refresh.
+//
 // # Read Performance
 //
-// Bacground synchronization ensures every client read will perform equally
+// Background synchronization ensures every client read will perform equally
 // well.  To facilitate efficient lookups of individual resources in the
 // cache each resource will be indexed via some form of hashing function
 // that uniquely identfies that resource.
@@ -209,8 +252,12 @@ type RefreshAheadCache[T any, TP CacheablePointer[T]] struct {
 	epoch Epoch
 	// refresh is used to refresh the entire cache in the background.
 	refresh RefreshFunc[T, TP]
-	// cache records the actual data.
+	// cache records the effective user-visible data after applying any pending
+	// overlay mutations.
 	cache cacheMap[T, TP]
+	// overlay records local mutations that must survive any refresh already in
+	// flight when they were written.
+	overlay overlayMap[T, TP]
 	// lock controls concurrent accesses.
 	lock sync.RWMutex
 	// invalidations is a channel that allows a client to synchronously
@@ -238,6 +285,125 @@ func (c *RefreshAheadCache[T, TP]) newEpoch() Epoch {
 	return Epoch{
 		epoch: c.nextEpoch.Add(1),
 	}
+}
+
+// InsertIfAbsent inserts item into the effective cache view when the key is not
+// already present.
+//
+// Callers must only invoke this after the corresponding backend insert has
+// synchronously committed. This path is primarily intended for singleton-style
+// inserts where a key can only be created once. The inserted value remains
+// authoritative until a later refresh that started after the insert replaces
+// it with backend state.
+func (c *RefreshAheadCache[T, TP]) InsertIfAbsent(item TP) error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	if c.cache == nil {
+		return ErrInvalid
+	}
+
+	index := item.Index()
+
+	if _, ok := c.cache[index]; ok {
+		// c.cache always reflects live overlay writes, so this covers both
+		// backend-populated entries and existing overlay entries.
+		return nil
+	}
+
+	if c.overlay == nil {
+		c.overlay = make(overlayMap[T, TP])
+	}
+
+	writeEpoch := c.newEpoch()
+
+	c.overlay[index] = overlayEntry[T, TP]{
+		item:  item,
+		epoch: writeEpoch,
+	}
+	c.cache[index] = item
+	c.epoch = writeEpoch
+
+	return nil
+}
+
+// Upsert writes item into the effective cache view whether or not the key is
+// already present.
+//
+// Callers must only invoke this after the corresponding backend write has
+// synchronously committed. If multiple writers race to upsert different values
+// for the same key, this cache does not define an additional winner-selection
+// policy beyond local serialization; the next authoritative refresh remains the
+// point where the cache is guaranteed to converge back to backend state. The
+// written value remains authoritative until a later refresh that started after
+// the write replaces it with backend state.
+func (c *RefreshAheadCache[T, TP]) Upsert(item TP) error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	if c.cache == nil {
+		return ErrInvalid
+	}
+
+	if c.overlay == nil {
+		c.overlay = make(overlayMap[T, TP])
+	}
+
+	index := item.Index()
+	writeEpoch := c.newEpoch()
+
+	c.overlay[index] = overlayEntry[T, TP]{
+		item:  item,
+		epoch: writeEpoch,
+	}
+	c.cache[index] = item
+	c.epoch = writeEpoch
+
+	return nil
+}
+
+// mergeAndPruneOverlayLocked rebuilds the effective user-visible cache view
+// from the freshly refreshed backend snapshot and any overlay entries that
+// landed after this refresh started. Older overlay entries are discarded and
+// the backend snapshot becomes authoritative for those keys.
+func (c *RefreshAheadCache[T, TP]) mergeAndPruneOverlayLocked(cache cacheMap[T, TP], refreshEpoch Epoch) cacheMap[T, TP] {
+	if len(c.overlay) == 0 {
+		return cache
+	}
+
+	// cache is the newly refreshed backend snapshot. Readers do not consume that
+	// snapshot directly: they consume the effective view after any still-pending
+	// local mutations have been reapplied.
+	//
+	// Rebuilding a fresh effective map here is deliberate. c.cache already
+	// includes prior overlay writes, so mutating it in place would risk carrying
+	// stale pre-refresh state forward. Starting from the fresh backend result and
+	// then reapplying only the overlay entries backed by newer mutations keeps
+	// the visible cache state deterministic.
+	effective := make(cacheMap[T, TP], len(cache)+len(c.overlay))
+	overlay := make(overlayMap[T, TP], len(c.overlay))
+
+	maps.Copy(effective, cache)
+
+	for index, entry := range c.overlay {
+		// Writes that landed while this refresh was already in flight must
+		// survive it. Older overlay entries yield to the refreshed backend
+		// snapshot on this refresh.
+		if !entry.epoch.after(refreshEpoch) {
+			continue
+		}
+
+		overlay[index] = entry
+		effective[index] = entry.item
+	}
+
+	if len(overlay) == 0 {
+		c.overlay = nil
+	} else {
+		c.overlay = overlay
+	}
+
+	return effective
 }
 
 // Run performs a synchronous refresh to pre load cache data and
@@ -407,6 +573,9 @@ func (c *RefreshAheadCache[T, TP]) doRefresh(ctx context.Context) error {
 		}
 	}()
 
+	// refreshEpoch must be allocated before the backend fetch starts. That epoch
+	// marks the refresh start boundary, allowing later local writes to receive a
+	// strictly newer epoch and remain authoritative over this refresh result.
 	refreshEpoch := c.newEpoch()
 
 	// Collect the refreshed data.
@@ -427,19 +596,38 @@ func (c *RefreshAheadCache[T, TP]) doRefresh(ctx context.Context) error {
 		cache[index] = data[i]
 	}
 
-	// Has anything actually changed?
-	// NOTE: this is performed unlocked as this function is the only thing
-	// that can modify the cache.
-	if cache.Equal(c.cache) {
-		return nil
-	}
-
-	// Write the new data.
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	c.epoch = refreshEpoch
-	c.cache = cache
+	effective := c.mergeAndPruneOverlayLocked(cache, refreshEpoch)
+
+	if effective.Equal(c.cache) {
+		// Epochs represent the identity of the visible cache snapshot, not the
+		// provenance of how it was assembled. If a refresh catches up to the
+		// current effective view exactly, then callers are still looking at the
+		// same snapshot and should be allowed to retain any memoized work keyed
+		// off the existing epoch. We still replace c.cache here because overlay
+		// pruning may have rebuilt the effective map even though the visible
+		// snapshot identity is unchanged.
+		c.cache = effective
+
+		return nil
+	}
+
+	// We only reach this branch when the visible effective view has changed.
+	// If it had not changed, the equality check above would have returned early
+	// and preserved the existing epoch. At this point a new visible snapshot
+	// needs a new epoch. If no overlay survives, the visible snapshot is exactly
+	// the refresh result so the refresh-start epoch is the right identity. If
+	// overlay still survives, the visible snapshot is a newly assembled merged
+	// view and must receive its own epoch.
+	if len(c.overlay) == 0 {
+		c.epoch = refreshEpoch
+	} else {
+		c.epoch = c.newEpoch()
+	}
+
+	c.cache = effective
 
 	return nil
 }

--- a/pkg/util/cache/refresh_ahead.go
+++ b/pkg/util/cache/refresh_ahead.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"maps"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -43,12 +44,12 @@ var (
 
 // Epoch represents a revision of the cache data.
 type Epoch struct {
-	epoch time.Time
+	epoch uint64
 }
 
 // Valid checks if a previous epoch is still valid against the current one.
 func (e Epoch) Valid(previous Epoch) bool {
-	return e.epoch.Equal(previous.epoch)
+	return e.epoch == previous.epoch
 }
 
 // Cacheable defines a cacheable type.
@@ -202,6 +203,8 @@ type invalidationRequest struct {
 type RefreshAheadCache[T any, TP CacheablePointer[T]] struct {
 	// options provide cache configuration.
 	options *RefreshAheadCacheOptions
+	// nextEpoch allocates strictly increasing epochs local to this cache instance.
+	nextEpoch atomic.Uint64
 	// epoch that the cache is valid for.
 	epoch Epoch
 	// refresh is used to refresh the entire cache in the background.
@@ -227,6 +230,13 @@ func NewRefreshAheadCache[T any, TP CacheablePointer[T]](refresh RefreshFunc[T, 
 	return &RefreshAheadCache[T, TP]{
 		refresh: refresh,
 		options: options,
+	}
+}
+
+// newEpoch allocates a new epoch local to this cache instance.
+func (c *RefreshAheadCache[T, TP]) newEpoch() Epoch {
+	return Epoch{
+		epoch: c.nextEpoch.Add(1),
 	}
 }
 
@@ -426,7 +436,7 @@ func (c *RefreshAheadCache[T, TP]) doRefresh(ctx context.Context) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	c.epoch.epoch = time.Now()
+	c.epoch = c.newEpoch()
 	c.cache = cache
 
 	return nil

--- a/pkg/util/cache/refresh_ahead.go
+++ b/pkg/util/cache/refresh_ahead.go
@@ -407,6 +407,8 @@ func (c *RefreshAheadCache[T, TP]) doRefresh(ctx context.Context) error {
 		}
 	}()
 
+	refreshEpoch := c.newEpoch()
+
 	// Collect the refreshed data.
 	data, err := c.refresh(ctx)
 	if err != nil {
@@ -436,7 +438,7 @@ func (c *RefreshAheadCache[T, TP]) doRefresh(ctx context.Context) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	c.epoch = c.newEpoch()
+	c.epoch = refreshEpoch
 	c.cache = cache
 
 	return nil

--- a/pkg/util/cache/refresh_ahead_internal_test.go
+++ b/pkg/util/cache/refresh_ahead_internal_test.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type internalOverlayType struct {
+	id     string
+	status string
+}
+
+func (t *internalOverlayType) Index() string {
+	return t.id
+}
+
+func (t *internalOverlayType) Equal(o *internalOverlayType) bool {
+	return *t == *o
+}
+
+// This test must live in the internal package because it verifies the private
+// overlay state directly. The external cache_test package covers the same race
+// at the public API boundary, but only the internal package can assert that the
+// overlay entry itself survives the in-flight refresh and is then discarded by
+// the next refresh.
+func TestOverlaySurvivesInFlightRefreshOnly(t *testing.T) {
+	t.Parallel()
+
+	var (
+		lock    sync.Mutex
+		items   = []*internalOverlayType{{id: "image", status: "ready"}}
+		started = make(chan struct{})
+		proceed = make(chan struct{})
+		block   atomic.Bool
+		once    sync.Once
+	)
+
+	refresh := func(_ context.Context) ([]*internalOverlayType, error) {
+		if block.Load() {
+			once.Do(func() { close(started) })
+
+			<-proceed
+		}
+
+		lock.Lock()
+		defer lock.Unlock()
+
+		current := make([]*internalOverlayType, len(items))
+		copy(current, items)
+
+		return current, nil
+	}
+
+	options := &RefreshAheadCacheOptions{
+		RefreshPeriod: time.Minute,
+	}
+
+	c := NewRefreshAheadCache[internalOverlayType](refresh, options)
+	require.NoError(t, c.Run(t.Context()))
+
+	block.Store(true)
+
+	done := make(chan error, 1)
+
+	go func() {
+		done <- c.Invalidate()
+	}()
+
+	<-started
+
+	lock.Lock()
+	items = []*internalOverlayType{{id: "image", status: "delete_pending"}}
+	lock.Unlock()
+
+	require.NoError(t, c.Upsert(&internalOverlayType{id: "image", status: "delete_pending"}))
+
+	close(proceed)
+	require.NoError(t, <-done)
+
+	c.lock.RLock()
+	require.Len(t, c.overlay, 1)
+	c.lock.RUnlock()
+
+	block.Store(false)
+
+	require.NoError(t, c.Invalidate())
+
+	c.lock.RLock()
+	require.Empty(t, c.overlay)
+	c.lock.RUnlock()
+}

--- a/pkg/util/cache/refresh_ahead_test.go
+++ b/pkg/util/cache/refresh_ahead_test.go
@@ -57,6 +57,41 @@ func (t *myType) Equal(o *myType) bool {
 	return *t == *o
 }
 
+type overlayType struct {
+	id     string
+	status string
+}
+
+func (t *overlayType) Index() string {
+	return t.id
+}
+
+func (t *overlayType) Equal(o *overlayType) bool {
+	return *t == *o
+}
+
+type overlayGenerator struct {
+	lock  sync.Mutex
+	items []*overlayType
+}
+
+func (g *overlayGenerator) set(items ...*overlayType) {
+	g.lock.Lock()
+	defer g.lock.Unlock()
+
+	g.items = items
+}
+
+func (g *overlayGenerator) refresh(_ context.Context) ([]*overlayType, error) {
+	g.lock.Lock()
+	defer g.lock.Unlock()
+
+	items := make([]*overlayType, len(g.items))
+	copy(items, g.items)
+
+	return items, nil
+}
+
 // staticGenerator provides a way to generate non changing data for the cache.
 type staticGenerator struct {
 	// size of the dataset.
@@ -399,6 +434,463 @@ func TestInvavalidationErrors(t *testing.T) {
 	time.Sleep(time.Second)
 
 	require.ErrorIs(t, c.Invalidate(), cache.ErrInvalid)
+}
+
+func TestInsertIfAbsentYieldsToNextRefreshWhenBackendOmitsKey(t *testing.T) {
+	t.Parallel()
+
+	generator := &overlayGenerator{}
+	generator.set(&overlayType{id: "base", status: "ready"})
+
+	options := &cache.RefreshAheadCacheOptions{
+		RefreshPeriod: time.Minute,
+	}
+
+	c := cache.NewRefreshAheadCache[overlayType](generator.refresh, options)
+	require.NoError(t, c.Run(t.Context()))
+
+	require.NoError(t, c.InsertIfAbsent(&overlayType{id: "new", status: "creating"}))
+
+	generator.set(&overlayType{id: "base", status: "ready"})
+
+	require.NoError(t, c.Invalidate())
+
+	_, err := c.Get("new")
+	require.ErrorIs(t, err, cache.ErrNotFound)
+}
+
+func TestUpsertYieldsToNextRefreshWhenBackendChangesKey(t *testing.T) {
+	t.Parallel()
+
+	generator := &overlayGenerator{}
+	generator.set(&overlayType{id: "image", status: "ready"})
+
+	options := &cache.RefreshAheadCacheOptions{
+		RefreshPeriod: time.Minute,
+	}
+
+	c := cache.NewRefreshAheadCache[overlayType](generator.refresh, options)
+	require.NoError(t, c.Run(t.Context()))
+
+	require.NoError(t, c.Upsert(&overlayType{id: "image", status: "delete_pending"}))
+
+	generator.set(&overlayType{id: "image", status: "ready"})
+
+	require.NoError(t, c.Invalidate())
+
+	updated, err := c.Get("image")
+	require.NoError(t, err)
+	require.Equal(t, "ready", updated.Item.status)
+}
+
+func TestInsertIfAbsentDoesNothingWhenKeyAlreadyVisible(t *testing.T) {
+	t.Parallel()
+
+	generator := &overlayGenerator{}
+	generator.set(&overlayType{id: "image", status: "ready"})
+
+	options := &cache.RefreshAheadCacheOptions{
+		RefreshPeriod: time.Minute,
+	}
+
+	c := cache.NewRefreshAheadCache[overlayType](generator.refresh, options)
+	require.NoError(t, c.Run(t.Context()))
+
+	before, err := c.Get("image")
+	require.NoError(t, err)
+
+	require.NoError(t, c.InsertIfAbsent(&overlayType{id: "image", status: "creating"}))
+
+	after, err := c.Get("image")
+	require.NoError(t, err)
+	require.Equal(t, "ready", after.Item.status)
+	require.True(t, after.Epoch.Valid(before.Epoch))
+}
+
+func TestInsertIfAbsentDoesNothingWhenLiveOverlayAlreadyExists(t *testing.T) {
+	t.Parallel()
+
+	generator := &overlayGenerator{}
+	generator.set(&overlayType{id: "base", status: "ready"})
+
+	options := &cache.RefreshAheadCacheOptions{
+		RefreshPeriod: time.Minute,
+	}
+
+	c := cache.NewRefreshAheadCache[overlayType](generator.refresh, options)
+	require.NoError(t, c.Run(t.Context()))
+
+	require.NoError(t, c.Upsert(&overlayType{id: "image", status: "delete_pending"}))
+
+	before, err := c.Get("image")
+	require.NoError(t, err)
+
+	require.NoError(t, c.InsertIfAbsent(&overlayType{id: "image", status: "creating"}))
+
+	after, err := c.Get("image")
+	require.NoError(t, err)
+	require.Equal(t, "delete_pending", after.Item.status)
+	require.True(t, after.Epoch.Valid(before.Epoch))
+}
+
+func TestUpsertInsertsWhenKeyMissing(t *testing.T) {
+	t.Parallel()
+
+	generator := &overlayGenerator{}
+	generator.set(&overlayType{id: "base", status: "ready"})
+
+	options := &cache.RefreshAheadCacheOptions{
+		RefreshPeriod: time.Minute,
+	}
+
+	c := cache.NewRefreshAheadCache[overlayType](generator.refresh, options)
+	require.NoError(t, c.Run(t.Context()))
+
+	require.NoError(t, c.Upsert(&overlayType{id: "missing", status: "delete_pending"}))
+
+	item, err := c.Get("missing")
+	require.NoError(t, err)
+	require.Equal(t, "delete_pending", item.Item.status)
+}
+
+func TestInsertIfAbsentErrorsBeforeRun(t *testing.T) {
+	t.Parallel()
+
+	c := cache.NewRefreshAheadCache[overlayType](func(context.Context) ([]*overlayType, error) {
+		return nil, nil
+	}, &cache.RefreshAheadCacheOptions{})
+
+	require.ErrorIs(t, c.InsertIfAbsent(&overlayType{id: "image", status: "creating"}), cache.ErrInvalid)
+}
+
+func TestUpsertErrorsBeforeRun(t *testing.T) {
+	t.Parallel()
+
+	c := cache.NewRefreshAheadCache[overlayType](func(context.Context) ([]*overlayType, error) {
+		return nil, nil
+	}, &cache.RefreshAheadCacheOptions{})
+
+	require.ErrorIs(t, c.Upsert(&overlayType{id: "image", status: "delete_pending"}), cache.ErrInvalid)
+}
+
+func TestInsertIfAbsentYieldsToNextRefreshWhenBackendContainsKey(t *testing.T) {
+	t.Parallel()
+
+	generator := &overlayGenerator{}
+	generator.set(&overlayType{id: "base", status: "ready"})
+
+	options := &cache.RefreshAheadCacheOptions{
+		RefreshPeriod: time.Minute,
+	}
+
+	c := cache.NewRefreshAheadCache[overlayType](generator.refresh, options)
+	require.NoError(t, c.Run(t.Context()))
+
+	require.NoError(t, c.InsertIfAbsent(&overlayType{id: "new", status: "creating"}))
+
+	generator.set(
+		&overlayType{id: "base", status: "ready"},
+		&overlayType{id: "new", status: "ready"},
+	)
+
+	require.NoError(t, c.Invalidate())
+
+	item, err := c.Get("new")
+	require.NoError(t, err)
+	require.Equal(t, "ready", item.Item.status)
+}
+
+func TestInsertIfAbsentYieldsToNextRefreshWhenBackendDropsKey(t *testing.T) {
+	t.Parallel()
+
+	generator := &overlayGenerator{}
+	generator.set(
+		&overlayType{id: "base", status: "ready"},
+		&overlayType{id: "new", status: "ready"},
+	)
+
+	options := &cache.RefreshAheadCacheOptions{
+		RefreshPeriod: time.Minute,
+	}
+
+	c := cache.NewRefreshAheadCache[overlayType](generator.refresh, options)
+	require.NoError(t, c.Run(t.Context()))
+
+	require.NoError(t, c.InsertIfAbsent(&overlayType{id: "new", status: "creating"}))
+
+	generator.set(&overlayType{id: "base", status: "ready"})
+
+	require.NoError(t, c.Invalidate())
+
+	_, err := c.Get("new")
+	require.ErrorIs(t, err, cache.ErrNotFound)
+}
+
+func TestConcurrentWritePreservesEpochAcrossStaleRefresh(t *testing.T) {
+	t.Parallel()
+
+	var (
+		lock    sync.Mutex
+		items   = []*overlayType{{id: "image", status: "ready"}}
+		started = make(chan struct{})
+		proceed = make(chan struct{})
+		block   atomic.Bool
+		once    sync.Once
+	)
+
+	refresh := func(_ context.Context) ([]*overlayType, error) {
+		lock.Lock()
+		current := make([]*overlayType, len(items))
+		copy(current, items)
+		lock.Unlock()
+
+		if block.Load() {
+			// Capture the stale backend snapshot first, then block. The concurrent
+			// Upsert that follows should therefore outrank this refresh and remain
+			// visible until a later refresh starts.
+			once.Do(func() { close(started) })
+
+			<-proceed
+		}
+
+		return current, nil
+	}
+
+	options := &cache.RefreshAheadCacheOptions{
+		RefreshPeriod: time.Minute,
+	}
+
+	c := cache.NewRefreshAheadCache[overlayType](refresh, options)
+	require.NoError(t, c.Run(t.Context()))
+
+	block.Store(true)
+
+	done := make(chan error, 1)
+
+	go func() {
+		done <- c.Invalidate()
+	}()
+
+	<-started
+
+	require.NoError(t, c.Upsert(&overlayType{id: "image", status: "delete_pending"}))
+
+	writeSnapshot, err := c.Get("image")
+	require.NoError(t, err)
+	require.Equal(t, "delete_pending", writeSnapshot.Item.status)
+
+	close(proceed)
+	require.NoError(t, <-done)
+
+	finalSnapshot, err := c.Get("image")
+	require.NoError(t, err)
+	require.Equal(t, "delete_pending", finalSnapshot.Item.status)
+	require.True(t, finalSnapshot.Epoch.Valid(writeSnapshot.Epoch))
+
+	require.NoError(t, c.Invalidate())
+
+	refreshedSnapshot, err := c.Get("image")
+	require.NoError(t, err)
+	require.Equal(t, "ready", refreshedSnapshot.Item.status)
+	require.False(t, refreshedSnapshot.Epoch.Valid(finalSnapshot.Epoch))
+}
+
+func TestConcurrentInsertIfAbsentPreservesEpochAcrossStaleRefresh(t *testing.T) {
+	t.Parallel()
+
+	var (
+		lock    sync.Mutex
+		items   = []*overlayType{{id: "base", status: "ready"}}
+		started = make(chan struct{})
+		proceed = make(chan struct{})
+		block   atomic.Bool
+		once    sync.Once
+	)
+
+	refresh := func(_ context.Context) ([]*overlayType, error) {
+		lock.Lock()
+		current := make([]*overlayType, len(items))
+		copy(current, items)
+		lock.Unlock()
+
+		if block.Load() {
+			once.Do(func() { close(started) })
+
+			<-proceed
+		}
+
+		return current, nil
+	}
+
+	options := &cache.RefreshAheadCacheOptions{
+		RefreshPeriod: time.Minute,
+	}
+
+	c := cache.NewRefreshAheadCache[overlayType](refresh, options)
+	require.NoError(t, c.Run(t.Context()))
+
+	block.Store(true)
+
+	done := make(chan error, 1)
+
+	go func() {
+		done <- c.Invalidate()
+	}()
+
+	<-started
+
+	require.NoError(t, c.InsertIfAbsent(&overlayType{id: "image", status: "creating"}))
+
+	writeSnapshot, err := c.Get("image")
+	require.NoError(t, err)
+	require.Equal(t, "creating", writeSnapshot.Item.status)
+
+	close(proceed)
+	require.NoError(t, <-done)
+
+	finalSnapshot, err := c.Get("image")
+	require.NoError(t, err)
+	require.Equal(t, "creating", finalSnapshot.Item.status)
+	require.True(t, finalSnapshot.Epoch.Valid(writeSnapshot.Epoch))
+
+	lock.Lock()
+	items = []*overlayType{{id: "base", status: "ready"}, {id: "image", status: "ready"}}
+	lock.Unlock()
+
+	require.NoError(t, c.Invalidate())
+
+	refreshedSnapshot, err := c.Get("image")
+	require.NoError(t, err)
+	require.Equal(t, "ready", refreshedSnapshot.Item.status)
+	require.False(t, refreshedSnapshot.Epoch.Valid(finalSnapshot.Epoch))
+}
+
+func TestRefreshWithSurvivingOverlayBumpsEpochWhenVisibleViewChanges(t *testing.T) {
+	t.Parallel()
+
+	var (
+		lock    sync.Mutex
+		items   = []*overlayType{{id: "image", status: "ready"}, {id: "other", status: "ready"}}
+		started = make(chan struct{})
+		proceed = make(chan struct{})
+		block   atomic.Bool
+		once    sync.Once
+	)
+
+	refresh := func(_ context.Context) ([]*overlayType, error) {
+		if block.Load() {
+			once.Do(func() { close(started) })
+
+			<-proceed
+		}
+
+		lock.Lock()
+		current := make([]*overlayType, len(items))
+		copy(current, items)
+		lock.Unlock()
+
+		return current, nil
+	}
+
+	options := &cache.RefreshAheadCacheOptions{
+		RefreshPeriod: time.Minute,
+	}
+
+	c := cache.NewRefreshAheadCache[overlayType](refresh, options)
+	require.NoError(t, c.Run(t.Context()))
+
+	block.Store(true)
+
+	done := make(chan error, 1)
+
+	go func() {
+		done <- c.Invalidate()
+	}()
+
+	<-started
+
+	lock.Lock()
+	items = []*overlayType{{id: "image", status: "ready"}, {id: "other", status: "updated"}}
+	lock.Unlock()
+
+	require.NoError(t, c.Upsert(&overlayType{id: "image", status: "delete_pending"}))
+
+	before, err := c.List()
+	require.NoError(t, err)
+
+	close(proceed)
+	require.NoError(t, <-done)
+
+	after, err := c.List()
+	require.NoError(t, err)
+	require.False(t, after.Epoch.Valid(before.Epoch))
+
+	image, err := c.Get("image")
+	require.NoError(t, err)
+	require.Equal(t, "delete_pending", image.Item.status)
+
+	other, err := c.Get("other")
+	require.NoError(t, err)
+	require.Equal(t, "updated", other.Item.status)
+}
+
+func TestRefreshWithSurvivingOverlayKeepsEpochWhenVisibleViewIsUnchanged(t *testing.T) {
+	t.Parallel()
+
+	var (
+		lock    sync.Mutex
+		items   = []*overlayType{{id: "image", status: "ready"}}
+		started = make(chan struct{})
+		proceed = make(chan struct{})
+		block   atomic.Bool
+		once    sync.Once
+	)
+
+	refresh := func(_ context.Context) ([]*overlayType, error) {
+		lock.Lock()
+		current := make([]*overlayType, len(items))
+		copy(current, items)
+		lock.Unlock()
+
+		if block.Load() {
+			once.Do(func() { close(started) })
+
+			<-proceed
+		}
+
+		return current, nil
+	}
+
+	options := &cache.RefreshAheadCacheOptions{
+		RefreshPeriod: time.Minute,
+	}
+
+	c := cache.NewRefreshAheadCache[overlayType](refresh, options)
+	require.NoError(t, c.Run(t.Context()))
+
+	block.Store(true)
+
+	done := make(chan error, 1)
+
+	go func() {
+		done <- c.Invalidate()
+	}()
+
+	<-started
+
+	require.NoError(t, c.Upsert(&overlayType{id: "image", status: "delete_pending"}))
+
+	before, err := c.Get("image")
+	require.NoError(t, err)
+	require.Equal(t, "delete_pending", before.Item.status)
+
+	close(proceed)
+	require.NoError(t, <-done)
+
+	after, err := c.Get("image")
+	require.NoError(t, err)
+	require.Equal(t, "delete_pending", after.Item.status)
+	require.True(t, after.Epoch.Valid(before.Epoch))
 }
 
 // BenchmarkRefreshAheadCacheGet tests single item retrieival performance.


### PR DESCRIPTION
## Summary
This changes `RefreshAheadCache` so successful local writes can become visible immediately through the cache without forcing a synchronous backend relist onto the request path.

The branch does three things:
- replaces `time.Time` cache epochs with a per-cache monotonic `uint64` epoch generator
- mints refresh epochs before the backend list starts so refresh ordering is based on refresh start, not refresh commit
- adds native write-through overlay support via `InsertIfAbsent` and `Upsert`

## Design Decisions
### 1. Epochs are local monotonic revisions
`Epoch` is now backed by a per-cache `atomic.Uint64` counter rather than `time.Time`.

Why:
- avoids clock-based ambiguity and aliasing
- gives strict ordering inside one cache instance
- keeps epochs opaque to callers while preserving equality-based memoization

### 2. Refresh epoch is minted before the backend fetch
`doRefresh()` allocates `refreshEpoch` before calling the user refresh callback.

Why:
- a refresh must be ordered by when it started, not when it eventually committed
- a local write that lands while a refresh is in flight gets a strictly newer epoch and must outrank that stale refresh

### 3. Local writes use a write-through overlay
The cache now supports:
- `InsertIfAbsent`
- `Upsert`

Both write through to the effective cache view immediately and also record an overlay entry tagged with the mutation epoch.

Why:
- callers can make successful writes visible immediately
- no synchronous invalidate/relist is required to get read-your-writes behaviour

### 4. Overlay scope is intentionally narrow
The overlay is only there to bridge writes that land during an already in-flight refresh.

Rule:
- if a write happens after a refresh has started, that write survives that refresh
- once a later refresh starts after the write, backend state is authoritative again and the older overlay entry is discarded

Why:
- this fixes the actual bug: a stale in-flight refresh must not erase a concurrent successful write
- it avoids turning the overlay into a long-lived reconciliation layer
- it also avoids needing special retirement-policy machinery just to decide when old overlays should disappear

### 5. Visible snapshot identity controls epoch churn
If a refresh rebuilds an effective visible cache view identical to the current one, the cache keeps the existing epoch.

Why:
- downstream memoization should only invalidate when the visible snapshot changes
- internal refresh activity alone should not force epoch churn

## Caveats
- This is intentionally a single-instance design. Epochs and overlays are process-local, so horizontal scaling would need a separate cache coherence/distribution mechanism.
- The overlay is not a general-purpose reconciliation layer. It only protects writes against the refresh window they raced with.
- There is still no dedicated cache-level delete operation. The cache relies on later authoritative refreshes to represent deletion in backend state.
- The model assumes that once a later refresh starts after the write, the backend snapshot is authoritative enough to replace the overlay. If backend propagation still lags at that point, the newer local value can still be lost on that later refresh. This trade-off is deliberate: the cache fixes the in-flight refresh race, but it does not try to solve general backend consistency.

## Testing
Added and updated tests to cover:
- stale in-flight refresh does not erase newer local writes for both `Upsert` and `InsertIfAbsent`
- the next refresh after that becomes authoritative again
- a surviving overlay keeps the existing epoch when the visible view is unchanged
- a surviving overlay gets a new visible epoch when other backend state changes at the same time
- `InsertIfAbsent` no-op semantics when a key is already visible, including live overlay state
- `Upsert` inserting when a key is missing
- pre-`Run()` error paths
- internal white-box validation that overlay state survives the in-flight refresh it raced with and is then discarded by the next refresh

## Verification
- `make license`
- `make validate`
- `make lint`
- `make generate`
- `make test-unit`
- `go test ./pkg/util/cache/...` with `GOCACHE=/tmp/gocache GOTMPDIR=/tmp`
