### PR TITLE
docs: add package knowledge graph and README coverage for core layers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /bin
 /sboms
+/.codex
 /charts/core/Chart.lock
 /charts/core/charts
 /charts/pact-broker/charts

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ This is the shared core library, it contains:
 * generic manager frameworks
 * generic server frameworks
 
+For the internal package knowledge graph and reading order, see
+[pkg/README.md](./pkg/README.md).
+
 ## Core Architecture
 
 Provisioners use continuous deployment (CD) as the foundation of cluster provisioning.
@@ -51,12 +54,16 @@ The general algorithm is:
 * If the deletion timestamp is set, it is being deleted
   * Run the deprovisioner
   * Update the custom resource status conditions
-  * If an error occurred, re-queue the reconcile, otherwise remove the finalizer to allow deletion and end reconciliation
+  * If deprovisioning yields, re-queue on the fixed yield timeout
+  * If an unexpected error occurs, return a hard reconcile error
+  * Otherwise remove the finalizer to allow deletion and end reconciliation
 * Otherwise we reconcile, either creating or updating resources
   * Add the finalizer to the custom resource if not already set to allow controlled deletion
   * Run the provisioner
   * Update the custom resource status conditions
-  * If an error occurred, re-queue the reconcile, otherwise end reconciliation
+  * If progress cannot continue, re-queue on the fixed yield timeout
+  * If an unexpected error occurs, update status and still re-queue on the fixed timeout rather than returning a raw reconcile error
+  * Otherwise end reconciliation
 
 Like the core controller logic, the reconciler handles status conditions, regardless of the custom resource type, in a generic manner to provide consistency.
 
@@ -66,12 +73,11 @@ The context contains a number of important values that can be propagated anywher
 These are:
 
 * Logger, provided by Controller Runtime
-* A Kubernetes client scoped to the current provisioner system
+* A Kubernetes client for the host or service cluster
+  * This is used primarily by the application provisioner to create applications for the CD driver and for other local control-plane operations
+* An active cluster scope describing where descendant provisioners should operate
   * By default this is the host system
-  * This is used primarily by the application provisioner to create applications for the CD driver
-* A cluster scoped to the current cluster that is being provisioned
-  * By default this is the host system
-  * When you invoke a provisioner in a remote cluster, this will be updated to that cluster
+  * When you invoke a provisioner in a remote cluster, this scope is rewritten to that cluster
   * This is used primarily to get secrets created in that cluster by an application e.g. credentials that need to be exposed to higher layers, typically Kubernetes configurations for nested remote clusters
   * It can also be used for hacks where the provisioner needs direct access to resources on the system, but this is discouraged
 * A CD driver that provides a generic interface to CD backends
@@ -115,13 +121,13 @@ These provide the following functionality:
   * Deprovisioning will occur in reverse order
 * Concurrent provisioner
   * Unordered provisioning where child provisioners can or must be provisioned independently of one another
-  * It will return nil if all succeed, or the first error that is encountered
+  * All children are launched in the same reconcile pass and it returns the first error preserved by the group after they have all returned
 * Conditional provisioner
   * Allows provisioners to be run if a predicate is true
   * Deprovisions if the predicate is false in order to facilitate removal of a single provisioner
 * Resource provisioner
   * For those times where you absolutely need to create a resource by hand, as opposed to via Helm
-  * Use of this should be restricted
+  * This is legacy hackery and should not be the pattern for new code
 
 As alluded to generic provisioners operate on other provisioners, thus can be composed into really complex logic that cannot be done with CD tools.
 
@@ -321,4 +327,3 @@ make pact-broker-upgrade-uat
 ```
 
 The deployment includes PostgreSQL for storage, ingress with TLS certificates, and automatic database cleanup configured per environment.
-

--- a/pkg/README.md
+++ b/pkg/README.md
@@ -1,0 +1,43 @@
+# pkg
+
+## Intention
+
+`pkg` is the shared platform library surface of this repository. It is not one
+framework. It is the collection of cross-cutting contracts, runtime layers, and
+historical baggage that sibling services and controllers depend on.
+
+The useful way to read it is as a small knowledge graph:
+
+- API/object contract:
+  [apis](./apis/README.md), [openapi](./openapi/README.md),
+  [constants](./constants/README.md), [errors](./errors/README.md)
+- Runtime/bootstrap and client layers:
+  [options](./options/README.md), [client](./client/README.md)
+- Reconciler/controller stack:
+  [provisioners](./provisioners/README.md), [manager](./manager/README.md),
+  [messaging](./messaging/README.md)
+- Server/API stack:
+  [server](./server/README.md)
+- Utilities and support layers:
+  [util](./util/README.md)
+
+## Reading Order
+
+- Start with [constants](./constants/README.md),
+  [errors](./errors/README.md), [apis/unikorn/v1alpha1](./apis/unikorn/v1alpha1/README.md),
+  and [openapi](./openapi/README.md) for the shared contract vocabulary.
+- Then read [client](./client/README.md) and [options](./options/README.md) for
+  process bootstrap and client construction.
+- controllers and provisioners:
+  [provisioners](./provisioners/README.md) -> [manager](./manager/README.md)
+- service APIs:
+  [server](./server/README.md)
+
+## Caveats
+
+- This tree contains both deliberately shared platform layers and a fair amount of
+  historical aggregation. Several packages are catch-alls that should eventually
+  split rather than grow.
+- Some subtrees are intentionally de-emphasized in this documentation pass:
+  `pkg/cd` because it is legacy in-tree CD surface, and most of `pkg/testing`
+  because it is test support rather than core runtime contract.

--- a/pkg/apis/README.md
+++ b/pkg/apis/README.md
@@ -1,0 +1,28 @@
+# pkg/apis
+
+## Intention
+
+`pkg/apis` contains Kubernetes API packages owned or carried by this repository.
+It is not the platform's entire CRD universe. Most service-specific APIs live in
+sibling repositories under their own `pkg/apis/unikorn/v1alpha1` trees.
+
+In this repository there are two different stories:
+
+- [unikorn](./unikorn/README.md): the real shared API substrate used across
+  repositories, plus the legacy in-tree `HelmApplication` CRD.
+- `argoproj`: local compatibility types for legacy ArgoCD/CD integration. These
+  are baggage from the old in-tree CD model, not a healthy foundation to build
+  more new API surface on.
+
+## Package Map
+
+- [unikorn](./unikorn/README.md): shared generic types, managed-resource
+  interfaces, status vocabulary, and the legacy `HelmApplication` schema.
+
+## Caveats
+
+- This tree is about Kubernetes object schema, not HTTP/OpenAPI schema. For the
+  service API contract, see [pkg/openapi](../openapi/README.md).
+- Not every API package here deserves equal strategic weight. `unikorn` is core
+  shared substrate. The Argo-related side is legacy compatibility surface that
+  should shrink rather than spread.

--- a/pkg/apis/unikorn/README.md
+++ b/pkg/apis/unikorn/README.md
@@ -1,0 +1,20 @@
+# pkg/apis/unikorn
+
+## Intention
+
+`pkg/apis/unikorn` is the versioned Kubernetes API surface owned by this repository.
+Today that means [v1alpha1](./v1alpha1/README.md).
+
+This directory is not the definition of every platform CRD. Most service-specific
+resources live in sibling repositories under their own `pkg/apis/unikorn/v1alpha1`
+packages. What this repository contributes here is the shared substrate those APIs
+build on, plus one legacy in-tree application descriptor type.
+
+## Package Map
+
+- [v1alpha1](./v1alpha1/README.md): shared generic API types, managed-resource interfaces, status helpers, semantic-version and networking primitives, and the legacy `HelmApplication` CRD.
+
+## Caveats
+
+- This is a repository API package, not the end-user HTTP API surface. For the HTTP/OpenAPI contract, see [pkg/openapi](../../openapi/README.md).
+- The `HelmApplication` side of `v1alpha1` is tied to the in-tree CD/application model. That part should shrink rather than spread as the platform continues moving away from in-tree CD.

--- a/pkg/apis/unikorn/v1alpha1/README.md
+++ b/pkg/apis/unikorn/v1alpha1/README.md
@@ -1,0 +1,84 @@
+# pkg/apis/unikorn/v1alpha1
+
+## Intention
+
+`pkg/apis/unikorn/v1alpha1` is the shared Kubernetes object-contract substrate for
+the platform. It defines the generic types, interfaces, and helper functions that
+multiple repositories reuse in their own `pkg/apis/unikorn/v1alpha1` packages so
+they do not each reinvent status conditions, semantic versions, IPv4 wrappers, tag
+types, or the managed-resource controller contract.
+
+This package also carries one real CRD of its own, `HelmApplication`. That makes
+the package slightly compromised: most of it is cross-repository substrate, while
+one part is legacy in-tree CD/application schema.
+
+## What Lives Here
+
+- Generic managed-resource interfaces used by the controller/provisioner layer:
+  `ResourceLabeller`, `ReconcilePauser`, `StatusConditionReader`,
+  `StatusConditionWriter`, and `ManagableResourceInterface`.
+- Shared condition vocabulary and helpers:
+  `Condition`, `ConditionType`, `ConditionReason`, `GetCondition()`,
+  `UpdateCondition()`.
+- Shared API value types:
+  `SemanticVersion`, `SemanticVersionConstraints`, `IPv4Address`, `IPv4Prefix`,
+  `Tag`, `TagList`, `MachineGeneric`, `NetworkGeneric`, and application reference
+  types.
+- Scheme registration for this repository's core API group.
+- `HelmApplication`, which describes installable application templates for the old
+  in-tree CD/application model.
+- `fake`, a minimal fake managed resource package used by tests and by broad scheme
+  assembly in [pkg/client](../../../client/README.md).
+
+## Relationships
+
+- [pkg/provisioners](../../../provisioners/README.md) and
+  [pkg/manager](../../../manager/README.md) rely on
+  `ManagableResourceInterface` as the generic controller-side resource contract.
+- [pkg/server/conversion](../../../server/conversion/README.md) and sibling service
+  repositories reuse the shared value types when projecting Kubernetes resources
+  into API responses.
+- [pkg/provisioners/application](../../../provisioners/application/README.md) uses
+  `HelmApplication` as the schema for the legacy in-tree application provisioning
+  path.
+
+## Invariants
+
+- If a resource is intended to participate in the generic manager/provisioner
+  lifecycle, it must implement the managed-resource interfaces defined here rather
+  than inventing a parallel contract elsewhere.
+- `Condition`, `ConditionType`, and `ConditionReason` are the repository's common
+  status vocabulary for managed resources. Higher layers such as
+  [pkg/manager](../../../manager/README.md) assume these meanings when updating or
+  interpreting status.
+- `SemanticVersion` and `SemanticVersionConstraints` intentionally smooth over the
+  platform's version-handling needs, including accepting both `1.2.3` and `v1.2.3`
+  forms because surrounding tooling such as Helm is looser than strict semver.
+- The IPv4 wrapper types exist so CRDs, JSON serialization, and unstructured
+  conversion all agree on one representation instead of every service inventing its
+  own string wrappers.
+
+## Caveats
+
+- The package boundary is mixed. Most of the package is generic substrate, but
+  `HelmApplication` is a specific legacy CRD tied to the in-tree CD/application
+  model. New generic types should be judged carefully so this package does not
+  become a dumping ground for unrelated cross-service schema.
+- `ManagableResourceInterface` is misspelled and now part of the public contract.
+  It is historical baggage, not a naming success.
+- The condition vocabulary is intentionally coarse. It supports shared manager and
+  conversion logic, but it is not a rich domain-specific state model.
+- `fake` is support baggage for tests and scheme assembly. It is useful, but it is
+  not a real API surface that production code should start depending on casually.
+- `HelmApplication` is a compatibility contract while the old application/CD model
+  still exists. If that model is removed, this type and its helpers should become
+  deletion candidates.
+
+## Cleanup Targets
+
+- `HelmApplication` can be removed once the remaining in-tree CD/application
+  consumers have been replaced and [pkg/provisioners/application](../../../provisioners/application/README.md)
+  no longer depends on it.
+- The `fake` package should stay narrow. If more elaborate fake CRDs are needed,
+  that is usually a sign the test should use the service-specific API package or a
+  more local test fixture instead.

--- a/pkg/client/README.md
+++ b/pkg/client/README.md
@@ -1,0 +1,46 @@
+# pkg/client
+
+## Intention
+
+`pkg/client` is a historical catch-all package for client-related concerns inside platform processes. It exists so repository-wide client behavior can be fixed once in one place, not because these responsibilities form a clean abstraction.
+
+Today it conflates three main functions:
+
+- Kubernetes client and scheme construction for processes that genuinely need to create their own in-cluster Kubernetes client
+- HTTP client security support for internal service-to-service API traffic, including MTLS material loading and principal-propagation signing around generated API clients
+- context-based client scoping for hierarchical provisioner execution as control moves from the local ArgoCD-managed layer into remote clusters
+
+The Kubernetes side is the sanctioned constructor path when a process genuinely needs to create its own in-cluster client. If an appropriate client is already available, use that instead of constructing another one. The point is to avoid ad hoc client construction scattered across the codebase.
+
+The HTTP side exists because generated API clients provide bindings, but not the platform's internal trust model. This package loads CA and client-certificate material from Kubernetes secrets, applies it to TLS configuration, and signs principal-bearing payloads so internal services can prove possession of the X.509 private key associated with their identity.
+
+The context side is legacy provisioner plumbing. It carries the active provisioning scope through a call graph so descendant provisioners operate on the currently scoped cluster by default, while still allowing explicit access to the local control-plane client when a step needs to reach back to the ArgoCD-managed layer. This was practical when deeply refactoring function-signature chains was expensive, but it is not a clean boundary.
+
+## Invariants And Guard Rails
+
+- This is an internal platform support package, not a general-purpose client library.
+- `New()` is the centralized in-cluster Kubernetes client constructor for processes that genuinely need to build their own client. Do not create Kubernetes clients ad hoc in random code paths.
+- If you are running inside a controller-runtime manager or controller, use the client provided there. For other processes such as APIs, monitors, or similar standalone components, use this package rather than open-coding client construction.
+- `NewScheme()` returns the repository's broad convenience scheme, not a minimal scheme. It intentionally registers Kubernetes types, Unikorn API types, fake Unikorn API types, and the local Argo shim before applying any extra `SchemeAdder` functions.
+- The Argo/CD-related scheme content exists for legacy compatibility with the old in-tree CD layer. New usage should not grow around it.
+- The HTTP client role here is transport and authentication support around internal generated clients, not API generation.
+- While this package still owns MTLS setup, it assumes certificate issuance and rotation are handled by an external system rather than by the client code itself.
+- TLS trust bundles and client certificates must come from correctly shaped `kubernetes.io/tls` secrets when using the current secret-backed MTLS path.
+- Payload signing is part of the current internal trust model for principal propagation between services. It is not a generic invitation to invent new signed application protocols.
+- Context scoping in this package controls the active provisioning target. Descendant provisioners are expected to operate on the currently scoped cluster unless they explicitly reach back to the local provisioner client.
+- Context-based scoping is legacy CD-layer plumbing and should be treated as constrained internal machinery, not as a pattern to spread further.
+
+## Caveats
+
+- The package name is misleading. `pkg/client` conflates unrelated responsibilities for legacy reasons and should be split into more intuitive packages.
+- A sensible split would be: Kubernetes client construction, internal HTTP client security support, and context-based provisioning scope.
+- The context-based scoping model is tied to the old ArgoCD/in-tree CD layer. It is legacy machinery that should shrink with that architecture rather than spread further.
+- The HTTP MTLS helper layer may become obsolete if service identity and transport concerns move out to something like SPIFFE.
+- `New()` starts the controller-runtime cache asynchronously and discards cache startup failure. Constructor success does not prove that the cache has started successfully.
+- `NewScheme()` is convenience-biased rather than minimal. It includes historical and compatibility-oriented registrations so callers in services or tests tend to get something that works for this repository.
+- The Argo shim and other CD-layer baggage remain in lock step with this repository for compatibility, but that is legacy behavior rather than a direction to build more dependencies around.
+- CA trust loading and client-certificate loading do not use identical configuration rules: CA loading only checks whether the secret name is set, while client-certificate loading requires both namespace and name. This is a current inconsistency and a potential bug if this package continues to own MTLS setup.
+- Client certificate reload is lazy and handshake-triggered rather than proactive.
+- Post-startup certificate reload is best-effort. If a reload fails after an earlier certificate was loaded successfully, the process keeps using the stale certificate rather than failing closed.
+- Reload uses a background context, so post-construction certificate refresh is not currently time-bounded.
+- The payload signing helpers are currently RSA-only. That restriction applies to message signing and verification, not to MTLS in general.

--- a/pkg/constants/README.md
+++ b/pkg/constants/README.md
@@ -1,0 +1,29 @@
+# pkg/constants
+
+## Intention
+
+`pkg/constants` is the repository's shared control vocabulary. It exists so platform code uses one canonical set of names and values for resource metadata and a small set of common orchestration semantics.
+
+Most of the package defines metadata contract shared across services, controllers, provisioners, and API conversion layers. That includes labels and annotations for naming, description, creator and modifier attribution, timestamps, organization and project scoping, user linkage, cluster attachment, application lookup, allocation linkage, and generic referenced-resource linkage.
+
+It also defines principal-prefixed metadata keys used when an intermediate service acts on a user's behalf and the platform still needs access to the original principal's identity context for attribution, quota, billing, or scoping decisions.
+
+The remainder of the package defines a few shared operational constants: the common finalizer token used by this management layer for explicit deletion control, the default yield timeout used for controlled retries, and the label-priority ordering used for specific label-tuple-based identity construction paths that need deterministic ordering from a map.
+
+## Invariants And Guard Rails
+
+- This package is a shared contract package, not a miscellaneous bucket for arbitrary constants.
+- Code that reads or writes the platform's standard labels and annotations should use these constants rather than open-coded strings.
+- The metadata keys here are part of the platform's resource contract. Changing them is a cross-repository compatibility concern, not a local refactor.
+- Principal-prefixed metadata is part of the platform's attribution and scoping model when services act on behalf of users. It is not decorative metadata.
+- `LabelPriorities()` defines the repository's canonical ordering for the label-tuple identity paths that depend on it. Callers should not invent local ordering rules for the same purpose.
+- `Finalizer` is the shared deletion-control token for this repository's management layer where cleanup requires explicit logic rather than raw Kubernetes garbage collection.
+- `DefaultYieldTimeout` is the shared default for controlled retry and yield behavior where reconciliation or provisioning work should back off and give another actor a turn.
+
+## Caveats
+
+- The package is mostly coherent as shared metadata and control vocabulary, but it is broader than pure metadata schema because it also carries a few operational defaults.
+- Several constants are tied to legacy in-tree CD or Argo-related workflows, especially application-oriented labels. They remain part of the current contract while those flows still exist, but they are candidates for deletion once the remaining ArgoCD and in-tree CD consumers have either been removed entirely or switched to whatever replaces those workflows.
+- Some names reflect historical model choices rather than ideal terminology. `PhysicalNetworkAnnotation` is a concrete example: its deprecation is intended, but removal requires downstream services such as `kubernetes` to migrate to the newer network identifier used by the current region and compute flows.
+- Centralization here improves consistency today, but some constants are only here because this repository became the aggregation point. Over time, some domain-specific metadata may be better owned by the package or repository that defines the primitive, for example organization and project metadata in identity-owned code and network metadata in region-owned code.
+- `DeveloperVersion` is legacy sentinel baggage from older developer-only behavior rather than a strong part of the package model.

--- a/pkg/errors/README.md
+++ b/pkg/errors/README.md
@@ -1,0 +1,26 @@
+# pkg/errors
+
+## Intention
+
+`pkg/errors` is the platform's canonical shared sentinel-error taxonomy. It exists to give code across this repository and sibling repositories one common set of coarse-grained error categories that can be wrapped with local detail and still recognized with `errors.Is(...)`.
+
+This package is not trying to model rich typed errors. Its role is to define shared category roots for recurring platform-level failure classes such as invalid context wiring, kubeconfig problems, malformed secrets, unexpected API status codes, internal consistency failures, unsupported key types, missing required keys, type conversion failures, resource-not-found conditions, and conflicts.
+
+The intended usage pattern is to wrap these sentinels with contextual detail using `%w` at the point of failure, then branch on the shared category at higher layers when behavior needs to differ.
+
+## Invariants And Guard Rails
+
+- This is the canonical shared sentinel set for the platform. If a category already exists here, code should reuse it rather than define another local sentinel with the same meaning.
+- These errors are for coarse-grained classification and control flow, not for carrying all user-facing detail by themselves.
+- Callers should preserve sentinel identity. Prefer wrapping with `%w` to add debugging context while keeping `errors.Is(...)` working across package boundaries.
+- The names here represent cross-cutting failure categories, not package-local implementation details.
+- `ErrConsistency` is for internal consistency failures, violated assumptions, and invariant-style errors inside the platform, not as a substitute for ordinary validation or user error reporting.
+- `ErrResourceNotFound` and `ErrConflict` are shared semantic categories intended to support common not-found and conflict handling across services.
+
+## Caveats
+
+- Canonical in intent does not mean canonical everywhere in practice yet. Some packages and sibling repositories still carry duplicate local sentinels for categories that already exist here, and those duplicates should be consolidated back onto this package as they are found.
+- That consolidation is an explicit cleanup action item, not a cosmetic preference. Duplicate generic sentinels weaken `errors.Is(...)`-based behavior and fragment the platform's error taxonomy.
+- This package is for generic cross-cutting error categories. Errors that are genuinely specific to a narrower domain or subsystem, such as a cache-specific conflict or a JOSE-specific key-format problem, should stay local to the package that owns that behavior.
+- The taxonomy here is intentionally shallow. It is useful for broad branching and classification, but many callers still need additional wrapped context to make an error actionable.
+- Some names are broad by design. That keeps reuse simple, but it also means callers must be disciplined about adding precise context rather than returning these sentinels naked.

--- a/pkg/manager/README.md
+++ b/pkg/manager/README.md
@@ -1,0 +1,51 @@
+# pkg/manager
+
+## Intention
+
+`pkg/manager` is the controller-runtime integration layer for the platform's reconciler/provisioner model. It is the package that turns the lower-level provisioner contract into an operational controller process with shared startup, reconcile, teardown, status, and deletion-ordering behavior.
+
+This package is where several lower-level ideas become enforceable runtime policy:
+
+- the reconciler-oriented provisioner contract from [pkg/provisioners](../provisioners/README.md)
+- the "yield instead of block" progress model driven by `provisioners.ErrYield`
+- the context-scoping and client-access model described in [pkg/client](../client/README.md)
+- the shared runtime/bootstrap options from [pkg/options](../options/README.md)
+- the controller-specific option layer in [options](./options/README.md)
+
+In practice `pkg/manager` does three jobs:
+
+- bootstraps controller processes through `Run(f ControllerFactory)`
+- implements the generic reconcile loop through `Reconciler`
+- manages cross-resource deletion ordering through resource-reference helper functions
+
+## Invariants And Guard Rails
+
+- `ControllerFactory` is the top-level integration contract for controller binaries built on this package.
+- `Run(f ControllerFactory)` is framework bootstrap code, not a generic library helper. It owns flag wiring, logging, OpenTelemetry setup, optional upgrade/initialize hooks, manager creation, controller creation, watch registration, and process startup.
+- `Reconciler` is the shared reconcile-policy implementation for manager-style resources. It injects the shared execution context that descendant provisioners depend on before invoking them.
+- That injected context includes:
+  - manager access via `pkg/manager`
+  - namespace and static Kubernetes client via [pkg/client](../client/README.md)
+  - active cluster scope via `client.ClusterContext`
+  - CD driver context
+  - managed-resource context for [pkg/provisioners/application](../provisioners/application/README.md)
+- `provisioners.ErrYield` is a first-class control signal here. It means "stop now and requeue on the fixed yield timeout" rather than "return a hard reconcile error."
+- During normal reconcile, even unexpected provisioner errors are intentionally translated into status updates plus fixed requeue, rather than returned as raw reconcile errors, to avoid controller-runtime exponential backoff harming throughput.
+- During delete reconcile, synthetic resource references and owned-resource finalizers are checked before child deprovisioning is allowed to proceed.
+- The resource-reference helpers implement the platform's deletion-ordering contract by encoding references as extra finalizers on referenced resources.
+- `ResourceReady()` is the shared readiness gate for dependent resources and returns `provisioners.ErrYield` when a dependency is not yet provisioned.
+
+## Lower Layers
+
+- [options](./options/README.md): controller-specific options built on [pkg/options](../options/README.md), including max concurrency and CD driver selection.
+- [provisioners](../provisioners/README.md): the child lifecycle contract that this package drives.
+- [client](../client/README.md): namespace/client/cluster context propagation used by the reconciler.
+- [provisioners/application](../provisioners/application/README.md): receives the managed-resource and CD contexts injected here.
+
+## Caveats
+
+- The package boundary is broad. It mixes process bootstrap, reconcile policy, context propagation, readiness helpers, and deletion/reference semantics.
+- `pkg/manager` is tightly coupled to the in-tree CD model. `getDriver()` currently hardcodes ArgoCD driver selection and treats anything else as unsupported.
+- The shared reconcile loop relies on substantial hidden context setup before provisioners run. That is efficient for repository consistency, but it means many downstream components depend on implicit prerequisites rather than explicit method arguments.
+- The deletion-ordering model is powerful but also compromised: resource references are encoded as finalizers, and `GenerateResourceReference()` still carries legacy naming baggage including the `unikorn-cloud.org` to `kubernetes.unikorn-cloud.org` group rewrite.
+- `Run()` exits the process directly on setup failures. That is appropriate for controller binaries, but it reinforces that this package is an operational framework layer rather than a clean reusable library.

--- a/pkg/manager/options/README.md
+++ b/pkg/manager/options/README.md
@@ -1,0 +1,43 @@
+# pkg/manager/options
+
+## Intention
+
+`pkg/manager/options` is the controller-specific layer on top of
+[pkg/options](../../options/README.md). It defines the common runtime flags needed
+by controller binaries in this repository after the generic process bootstrap
+concerns have already been handled.
+
+This package is not a general controller configuration framework. It is the shared
+flag surface for controller processes that use [pkg/manager](../README.md).
+
+## What Lives Here
+
+- `Options`, which embeds `options.CoreOptions` and adds:
+  - `MaxConcurrentReconciles`
+  - `CDDriver`
+- `AddFlags()`, which registers those controller-specific flags and seeds the
+  default CD driver.
+
+## Relationships
+
+- [pkg/options](../../options/README.md) provides the common process-bootstrap
+  layer for logging, telemetry, namespace scoping, and similar runtime concerns.
+- [pkg/manager](../README.md) is the runtime layer that consumes these options when
+  starting controller processes.
+
+## Invariants
+
+- Controller binaries should embed or reuse this options struct rather than
+  re-declaring common manager flags in each command.
+- `MaxConcurrentReconciles` is the shared tuning knob for controller throughput and
+  memory tradeoffs.
+- `CDDriver` exists because the manager layer still carries legacy in-tree CD
+  integration and needs one common way to select that backend.
+
+## Caveats
+
+- This package inherits the same strategic blemish as [pkg/manager](../README.md):
+  the CD-driver flag is legacy surface tied to the old in-tree CD model.
+- The option set is intentionally small. If more flags accumulate here, that is a
+  sign the controller layer may be leaking service-specific policy into what should
+  stay a shared manager bootstrap surface.

--- a/pkg/messaging/README.md
+++ b/pkg/messaging/README.md
@@ -1,0 +1,33 @@
+# pkg/messaging
+
+## Intention
+
+`pkg/messaging` defines a narrow message-queue abstraction for resource lifecycle events. Its job is to let platform code consume replayable resource messages without coupling directly to a specific backend implementation.
+
+The key semantic is replayable lifecycle delivery. Implementations must be able to replay all currently active resources on startup so consumers can re-witness state after restarts and continue any required work that might otherwise have been missed.
+
+The main proven use case for that replay behavior today is deletion recovery. Deletion in the platform is often reference-driven rather than immediate. A resource such as a project may remain blocked from deletion while other resources still reference it. Messaging consumers are used to fan deletion outward, remove dependents, and allow those references to clear so deletion can complete eventually.
+
+The abstraction is intended to support backends such as Kubernetes today and
+systems such as Kafka or NATS later. The current envelope is deliberately small:
+it carries a resource ID and optional deletion timestamp, and consumers are
+expected to rehydrate any richer state they need from the system of record.
+
+See [kubernetes](./kubernetes/README.md) for the current backend and
+[consumer](./consumer/README.md) for the current reusable consumer pattern.
+
+## Invariants And Guard Rails
+
+- This package is a resource-lifecycle messaging abstraction, not a general-purpose event bus API.
+- Queue implementations must replay all active resources on startup so consumers can recover missed work after restarts.
+- If a consumer returns an error, the queue implementation must requeue or retry the event rather than treating it as successfully handled.
+- Consumers should be written to tolerate replay and repeated delivery. The contract assumes recovery and retries, not exactly-once processing.
+- The envelope is intentionally minimal. Consumers should derive any richer state they need from the resource ID and the system of record rather than expecting a full event payload here.
+- Deletion is the most important currently proven semantic carried by this abstraction. A nil deletion timestamp routes the message as a live or non-deleting resource event; a populated deletion timestamp means deletion fan-out or other cleanup logic may need to run.
+
+## Caveats
+
+- The abstraction is broader in intent than in its current in-tree implementation. Today there is only one backend, and it is effectively controller-runtime reconciliation wrapped in a queue-shaped interface.
+- The current Kubernetes backend is tightly coupled to controller-runtime manager and reconcile mechanics, so future non-Kubernetes backends are intended but not yet pressure-tested by this abstraction.
+- The envelope is intentionally sparse. That keeps queue semantics simple, but it also limits this abstraction to consumers that can rehydrate needed state from the system of record.
+- The main proven use case today is deletion fan-out and cascading cleanup. If future consumers expect richer event semantics, this package contract may need to grow or split.

--- a/pkg/messaging/consumer/README.md
+++ b/pkg/messaging/consumer/README.md
@@ -1,0 +1,47 @@
+# pkg/messaging/consumer
+
+## Intention
+
+`pkg/messaging/consumer` contains reusable consumers for the
+[pkg/messaging](../README.md) contract. Today that mostly means one thing:
+deletion-driven local fan-out.
+
+The package is not a broad library of message-processing patterns. It is a narrow
+home for consumers that can be reused across services when lifecycle events need
+to trigger predictable follow-up work.
+
+## What Lives Here
+
+- `CascadingDelete`, a consumer that:
+  - ignores live events
+  - reacts to deletion events
+  - lists local resources, optionally filtered by a resource-ID label
+  - issues foreground deletes so downstream cleanup can complete before the
+    referenced object is finally removed
+
+## Relationships
+
+- [pkg/messaging](../README.md) defines the envelope, replay, and retry contract.
+- [pkg/messaging/kubernetes](../kubernetes/README.md) is the current backend that
+  delivers those envelopes.
+- [pkg/manager](../../manager/README.md) and the broader finalizer/reference model
+  are the reason this consumer exists: deletion of one resource often has to fan
+  out before another resource may finish disappearing.
+
+## Invariants
+
+- `CascadingDelete` treats deletion as the only actionable event. A nil deletion
+  timestamp is intentionally ignored.
+- If `WithResourceLabel()` is used, the consumer assumes that label identifies the
+  local resources owned by or referencing the deleted upstream resource.
+- Foreground deletion is used on purpose so owner-reference and finalizer-driven
+  cleanup blocks until dependents are actually cleared.
+
+## Caveats
+
+- This is a sharp tool. If the resource label is wrong or omitted carelessly, the
+  consumer can delete far more than intended.
+- The consumer is only thinly generic. It relies on the local resource type being
+  listable via `client.ObjectList` and on the system of record being Kubernetes.
+- The package currently has one real consumer. If more appear, they should earn
+  their place by being genuinely reusable rather than just being nearby.

--- a/pkg/messaging/kubernetes/README.md
+++ b/pkg/messaging/kubernetes/README.md
@@ -1,0 +1,53 @@
+# pkg/messaging/kubernetes
+
+## Intention
+
+`pkg/messaging/kubernetes` is the current in-tree backend for
+[pkg/messaging](../README.md). It makes the queue contract work by wrapping
+controller-runtime manager/controller machinery around one watched Kubernetes
+object type and translating reconcile events into `messaging.Envelope` deliveries.
+
+This is a real backend, but it is not evidence of a mature multi-backend queue
+abstraction. Today the abstraction has one implementation, and that implementation
+is essentially controller-runtime reconciliation dressed up as a queue.
+
+## What Lives Here
+
+- `MessageQueue`, which owns:
+  - manager construction
+  - leader election
+  - watch registration for one object type
+  - in-process fan-out to registered consumers
+- `Run()`, which starts the manager and controller.
+- `Reconcile()`, which loads the watched object and converts it into the minimal
+  `messaging.Envelope` understood by consumers.
+
+## Relationships
+
+- [pkg/messaging](../README.md) defines the replay/retry contract this backend is
+  expected to satisfy.
+- [pkg/messaging/consumer](../consumer/README.md) contains the current main
+  consumer pattern this backend drives.
+
+## Invariants
+
+- This backend watches exactly one Kubernetes object type per queue instance.
+- Leader election is always enabled because Kubernetes does not partition work like
+  an external message broker would.
+- Delivery semantics come from controller-runtime reconciliation:
+  - active objects are replayed by informer/controller startup behavior
+  - consumer failure causes reconcile failure and therefore retry
+- The emitted envelope is intentionally sparse: resource name plus optional
+  deletion timestamp. Consumers are expected to rehydrate real state from the
+  system of record.
+
+## Caveats
+
+- This is not an independent queue model. It is a controller-runtime wrapper with
+  queue-like semantics.
+- Only one backend exists today. Future Kafka/NATS-style backends are intended by
+  the abstraction but have not yet pressure-tested it.
+- `Reconcile()` reuses the same `q.object` storage when fetching objects. That is
+  fine in the current narrow usage, but it reinforces that this code is shaped
+  around controller-runtime flow rather than a broad general-purpose messaging
+  runtime.

--- a/pkg/openapi/README.md
+++ b/pkg/openapi/README.md
@@ -1,0 +1,32 @@
+# pkg/openapi
+
+## Intention
+
+`pkg/openapi` is the platform's shared OpenAPI substrate. It provides the common schema fragments, generated types, embedded specification loading, and runtime route lookup machinery that other service APIs build on.
+
+Most of the package is generated from the shared OpenAPI specification. That generated layer defines reusable schema fragments, enums, generic error shapes, resource metadata models, and the embedded spec-loading functions used by downstream service-specific OpenAPI packages.
+
+The handwritten [helpers](./helpers/README.md) layer is load-bearing runtime
+infrastructure for the platform middleware stack. In particular, `FindRoute`
+performs efficient path-based schema lookup from an already-routed Chi request,
+resolves the matching OpenAPI operation, and returns both route metadata and
+extracted path parameters.
+
+That route metadata is then used to drive handler and middleware behavior from schema-defined data, including validation, authorization, CORS handling, auditing, and related request-processing decisions.
+
+## Invariants And Guard Rails
+
+- This package is shared OpenAPI contract infrastructure, not a generic HTTP utility package.
+- The generated schema and types here are intended to be imported and reused by service-specific OpenAPI packages rather than redefined independently.
+- The generated layer is the source of truth for the shared OpenAPI fragments it embeds. Manual edits belong in the specification or generation pipeline, not in generated files.
+- `GetSwagger()` exposes the embedded shared specification, and `PathToRawSpec()` exists to support external reference resolution for downstream generated OpenAPI packages using import-mapped shared schema fragments.
+- `helpers.FindRoute()` is part of the runtime contract of the platform middleware stack. It is not optional convenience code.
+- Route lookup is intentionally coupled to requests that have already been routed by Chi. That is a performance choice: the platform reuses the routed path context for efficient schema lookup rather than paying for a second generic route-resolution pass.
+- Middleware and handlers should derive schema-driven behavior from the resolved OpenAPI route rather than duplicate path logic separately.
+
+## Caveats
+
+- Most of this package is generated code, so the real design surface is smaller than the file count suggests.
+- The handwritten helper layer is small, but it is operationally critical because middleware behavior depends on correct route-to-schema resolution.
+- The package mixes static contract artifacts and runtime lookup logic. That is intentional for the platform, but it means the boundary is broader than "just generated types".
+- The route lookup logic is coupled to Chi routing semantics and the platform's middleware ordering by design. Using it outside an already-routed Chi request path is the wrong usage pattern, not a generally supported mode.

--- a/pkg/openapi/helpers/README.md
+++ b/pkg/openapi/helpers/README.md
@@ -1,0 +1,49 @@
+# pkg/openapi/helpers
+
+## Intention
+
+`pkg/openapi/helpers` is the runtime route-resolution layer for the platform's
+OpenAPI-driven middleware stack. It is not a generic schema toolkit. Its job is to
+take an already-routed HTTP request, map it efficiently onto the matching OpenAPI
+path and operation, and return the route metadata that downstream middleware uses
+to decide how the handler should behave.
+
+This is the load-bearing runtime half of [pkg/openapi](../README.md). The
+generated/spec side defines the schema. This package makes that schema usable on
+live requests without doing an expensive second routing pass.
+
+## What Lives Here
+
+- `Schema`, a thin cached wrapper around a loaded `openapi3.T`.
+- `NewSchema()`, which loads and retains the parsed specification.
+- `FindRoute()`, which uses Chi's existing route context to resolve the matching
+  OpenAPI path, operation, and path parameters.
+
+## Relationships
+
+- [pkg/openapi](../README.md) owns the shared generated schema/types and embedded
+  spec-loading functions.
+- [pkg/server/middleware](../../server/middleware/README.md), especially
+  `routeresolver` and `cors`, depends on this package to attach route metadata to
+  request context once and reuse it downstream.
+- [pkg/server/errors](../../server/errors/README.md) provides the canonical API
+  errors returned when route or method lookup fails.
+
+## Invariants
+
+- Requests are expected to have already passed through Chi routing. `FindRoute()`
+  does not perform a generic independent router/spec match. It reuses the routed
+  path context deliberately for performance.
+- Middleware ordering is therefore part of the contract. Using this package before
+  routing, or outside the standard request pipeline, is the wrong execution model.
+- `Schema` should be constructed once and reused. Parsing the OpenAPI document is
+  intentionally separated from per-request route resolution because loading the
+  spec repeatedly is unnecessarily expensive.
+
+## Caveats
+
+- This package is tightly coupled to Chi. That is a deliberate performance tradeoff,
+  not an accidental implementation detail.
+- `FindRoute()` assumes the routed path exists in the OpenAPI specification too.
+  If router definitions and schema drift apart, this package turns that drift into
+  runtime 404/405-style API errors.

--- a/pkg/options/README.md
+++ b/pkg/options/README.md
@@ -1,0 +1,30 @@
+# pkg/options
+
+## Intention
+
+`pkg/options` is the shared runtime-options package for platform processes. It does not provide a general configuration framework. Its job is to define the common CLI flag surface and bootstrap behavior that services, controllers, and consumers are expected to share for core process concerns.
+
+This package is also part of the deployment contract, not just the Go API. The common flags defined here are expected to stay aligned with shared chart helpers so services expose a consistent runtime configuration surface through Helm as well as through code.
+
+It currently provides two shared option groups:
+
+- `CoreOptions` as the common process-bootstrap base layer for namespace, logging, and observability setup
+- `ServerOptions` for standard HTTP listener and timeout configuration used by API processes
+
+## Invariants And Guard Rails
+
+- `CoreOptions` is the canonical base options layer for common process concerns. Higher-level service and controller option structs should embed or build on it rather than redefining namespace, logging, or OTLP flags locally.
+- `ServerOptions` is the canonical shared flag surface for standard API server listener and timeout behavior.
+- `AddFlags()` methods here define shared CLI contract. Changes to flag names, meanings, or defaults have operational impact beyond this package.
+- `SetupLogging()` is the common path for wiring zap, controller-runtime logging, `klog`, and OpenTelemetry logging consistently in the same process.
+- `SetupOpenTelemetry()` is the common path for process-wide observability bootstrap. It sets global trace propagation plus tracer and meter providers for the process.
+- When an OTLP endpoint is configured, `SetupOpenTelemetry()` also bridges controller-runtime Prometheus metrics into OTLP export rather than only enabling trace export.
+- Helm chart helpers and values that surface these options are expected to stay aligned with the structs and flags defined here.
+
+## Caveats
+
+- The package name is broader than the actual scope. This is really shared runtime and bootstrap options, not a home for arbitrary application-specific settings.
+- `CoreOptions` mixes several cross-cutting deployment concerns in one struct: namespace, logging, tracing, and metrics bootstrap. That is practical for shared process setup, but it is not a particularly clean abstraction boundary.
+- The package registers flags and performs bootstrap wiring, but it does not validate higher-level application configuration or guarantee that callers use the options sensibly.
+- `ServerOptions` only covers generic listener and timeout behavior. Service-specific server dependencies, middleware, auth, and peer-client options belong in higher-level packages that embed this base layer.
+- The deployment contract is partly external to this package. If shared Helm helpers drift from these structs and flags, the shared process configuration contract is broken even if the Go code still compiles and starts.

--- a/pkg/provisioners/README.md
+++ b/pkg/provisioners/README.md
@@ -1,0 +1,40 @@
+# pkg/provisioners
+
+## Intention
+
+`pkg/provisioners` defines the repository's reconciler-oriented provisioning contract. It is the abstraction layer used to drive resource lifecycle through idempotent `Provision(ctx)` and `Deprovision(ctx)` operations that can make partial progress, yield, and converge over repeated controller-runtime retries.
+
+This package itself is intentionally small:
+
+- the `Provisioner` and `ManagerProvisioner` interfaces
+- the `RemoteCluster` interface for deriving remote kubeconfigs and identities
+- shared metadata for provisioner names
+- shared sentinel errors, especially `ErrYield`
+
+Most of the real behavior lives in the lower-level adapters and combinators under this directory.
+
+## Invariants And Guard Rails
+
+- Provisioners are intended to run inside reconcilers. They are expected to be idempotent and safe to revisit across repeated reconcile passes.
+- `ErrYield` is a core part of the model, not an edge case. It means "stop now and let the controller retry later" when a provisioner would otherwise block for too long waiting on external progress.
+- The preferred progress model is framework-driven retry, not long local retry loops. Provisioners should generally fail or yield quickly and let controller-runtime handle fairness and requeue.
+- `Deprovision(ctx)` is part of the same convergence model. It may make partial progress and return `ErrYield` while waiting for external deletion or teardown to complete.
+- `ManagerProvisioner` is the top-level provisioner shape that bridges directly into the controller-runtime layer for managed resources.
+- `RemoteCluster` is the narrow interface used by remote-scope provisioners to derive the target cluster identity and kubeconfig.
+
+## Package Map
+
+- [application](./application/README.md): CD-managed Helm application provisioner. Resolves application/version, derives application identity from resource scope, applies generator customizations, and delegates lifecycle to the CD driver.
+- [remotecluster](./remotecluster/README.md): switches active provisioning scope into a remote cluster, constructs the remote client, and coordinates shared remote lifecycle for descendants.
+- [serial](./serial/README.md): ordered composition combinator for dependency-sensitive children. Provision in order, deprovision in reverse order.
+- [concurrent](./concurrent/README.md): parallel composition combinator for independent children that should make progress in the same reconcile pass.
+- [conditional](./conditional/README.md): binary desired-state gate where predicate false means actively deprovision the child, not merely skip it.
+- [resource](./resource/README.md): legacy single-`client.Object` adapter. Historical hack, not a recommended pattern for new code.
+- [util](./util/README.md): small provisioner-side helper bucket, mostly scheduling/config-generation fragments and a couple of operational helpers.
+
+## Caveats
+
+- `pkg/provisioners` is a contract layer, not a clean architecture in itself. Much of the real complexity is pushed into the subpackages, especially `application` and `remotecluster`.
+- The whole model assumes reconciler-friendly behavior: idempotence, quick yields, and retry-based convergence. If child provisioners block internally or depend on one-shot success, the abstraction breaks down.
+- Several important subpackages are tightly coupled to the older context-scoping and in-tree CD model documented in [pkg/client](../client/README.md), especially [application](./application/README.md) and [remotecluster](./remotecluster/README.md).
+- Not every subpackage here is equally healthy. `resource` is legacy baggage, and some of the extension seams in `application` are historical compromise rather than clean design.

--- a/pkg/provisioners/application/README.md
+++ b/pkg/provisioners/application/README.md
@@ -1,0 +1,37 @@
+# pkg/provisioners/application
+
+## Intention
+
+`pkg/provisioners/application` is the provisioner adapter for CD-managed Helm applications. It turns a managed resource plus an application lookup function into the canonical CD driver operations needed to create, update, and delete an application instance.
+
+This package is not a generic Helm abstraction and it is not merely a thin wrapper around the CD driver. It encodes the repository's model for:
+
+- resolving which version of a `HelmApplication` applies to the current managed resource
+- deriving a stable application identity from that resource
+- translating resource scope, remote-cluster scope, and optional generator customizations into a `cd.HelmApplication`
+- delegating the actual application lifecycle to the CD driver
+
+Like [pkg/provisioners/remotecluster](../remotecluster/README.md), this package is tightly coupled to the context-based provisioning-scope model described in [pkg/client](../../client/README.md). It expects context to carry both the managed resource and the active cluster scope that determine where the application should be installed.
+
+## Invariants And Guard Rails
+
+- Within the current in-tree CD/application model, this is the main provisioner adapter for CD-managed Helm applications.
+- `New(applicationGetter)` requires a lookup function that resolves the effective `HelmApplication` object and version for the current context. The provisioner does not own application discovery itself.
+- `Provision()` and `Deprovision()` both call `initialize()` at execution time, not at construction time, so application resolution happens in a path that can return normal reconcile errors.
+- Application identity is derived from both sides of the relationship: the application name selected during initialization and the managed resource labels carried in context. Those resource labels are sorted deterministically so the CD-layer identity remains stable.
+- Destination cluster identity comes from the active `client.ClusterContext` in context. Descendants are therefore expected to run under the correct provisioning scope before this provisioner is invoked.
+- `InNamespace()` overrides the application namespace explicitly. Otherwise the namespace comes from the application version, falling back to `default`.
+- `WithGenerator()` is the historical customization seam for adding implicit release names, parameters, values, namespace metadata, ignored-difference customizations, and lifecycle hooks around an otherwise standard application template.
+- `AllowDegraded()` deliberately weakens the success condition so degraded application health is accepted for cases where that is an intentional repository policy.
+- `PreDeprovisionHook` runs before application deletion and `PostProvisionHook` runs only after successful provisioning.
+- Deprovision propagates `remotecluster.BackgroundDeletionFromContext(ctx)` into the CD driver's delete path so descendant cleanup can respect doomed-remote semantics.
+
+## Caveats
+
+- This package mixes several concerns in one place: application lookup, version selection, identity derivation, template customization, lifecycle hooks, remote-scope interpretation, and CD-driver delegation.
+- The package is heavily context-driven. It assumes the managed resource is already present in context and that the active cluster scope has already been set correctly. If either hidden prerequisite is missing or wrong, behavior will be wrong in ways the constructor cannot prevent.
+- `WithGenerator()` is intentionally open-ended and therefore compromise-prone. It is a plugin-style `any` plus a pile of optional interface assertions, not a clean extension model. The typed generator interfaces are useful, but the generic `Customizer` hook is effectively an escape hatch and should be treated with suspicion.
+- `AllowDegraded()` is not a neutral option. It encodes a policy exception that should only be used when degraded application health is genuinely acceptable for that application.
+- `PreDeprovisionHook` and `PostProvisionHook` are operational escape hatches around the main CD lifecycle. Useful, but also evidence that some managed applications still need extra bespoke handling.
+- `getResourceID()` still depends on `util.Keys()` for deterministic label ordering. That is one of the remaining obstacles to deleting the now-obsolete helper in `pkg/util`.
+- This package is coupled to the CD/application model. If the old in-tree CD layer continues to shrink or is replaced, this package would likely need to be split or redesigned rather than carried forward unchanged.

--- a/pkg/provisioners/concurrent/README.md
+++ b/pkg/provisioners/concurrent/README.md
@@ -1,0 +1,23 @@
+# pkg/provisioners/concurrent
+
+## Intention
+
+`pkg/provisioners/concurrent` is the parallel-composition combinator for provisioners that do not depend on each other's ordering and can make progress in the same reconcile pass.
+
+It is intended for reconciler-driven use, where child provisioners are expected to be idempotent, quick to yield, and safe to revisit on later retry passes.
+
+## Invariants And Guard Rails
+
+- `Provision(ctx)` starts all child provisioners concurrently and waits for them all to return.
+- `Deprovision(ctx)` starts all child deprovision operations concurrently and waits for them all to return.
+- This combinator does not fail fast at the group level. A failure or yield from one child does not stop siblings that are already running in the same pass.
+- The intended model is that child provisioners themselves fail or yield quickly rather than blocking for long periods.
+- This package is appropriate only when children are genuinely independent and the system benefits from making parallel progress in one reconcile pass.
+- The broader convergence model is still controller-driven retry. Partial progress is expected and later passes are expected to complete the remaining work.
+
+## Caveats
+
+- This package does not manage dependencies. If children actually require ordering, the wrong combinator has been chosen.
+- The returned error is only the first one preserved by `errgroup`, even if multiple children failed. The implementation logs child failures individually to reduce observability loss, but the API surface still collapses them.
+- Because the group does not try to cancel sibling work on the first failure, this combinator depends on child provisioners being reconciler-friendly and fast to yield instead of sitting in long local retry loops.
+- This is not a supervisor for long-running blocking tasks. If children block excessively, concurrent composition amplifies that bad behavior rather than fixing it.

--- a/pkg/provisioners/conditional/README.md
+++ b/pkg/provisioners/conditional/README.md
@@ -1,0 +1,25 @@
+# pkg/provisioners/conditional
+
+## Intention
+
+`pkg/provisioners/conditional` is a small provisioner combinator for optional subordinate resources. It gates a child provisioner behind a predicate, but the key behavior is stronger than simple skipping: when the predicate is false, the child is actively deprovisioned.
+
+This makes the package useful for feature- or capability-dependent child provisioners where the desired state is binary:
+
+- predicate true: the child should exist
+- predicate false: the child should not exist
+
+## Invariants And Guard Rails
+
+- `Provision(ctx)` does not mean "try to provision if enabled and otherwise do nothing". It means "drive the child to the desired existence state for the current predicate value."
+- If the predicate is true, `Provision(ctx)` delegates to the child provisioner's `Provision(ctx)`.
+- If the predicate is false, `Provision(ctx)` delegates to the child provisioner's `Deprovision(ctx)`.
+- `Deprovision(ctx)` always delegates to the child provisioner's `Deprovision(ctx)`, regardless of predicate value, so cleanup still happens during parent teardown even when the child was conditionally disabled.
+- This combinator is appropriate when predicate false really means the child resource must not exist.
+
+## Caveats
+
+- The predicate is just `func() bool`. It carries no context, error handling, or structured explanation of why the child is enabled or disabled.
+- This package encodes removal semantics, not skip semantics. If a caller wants "disabled for now, but preserve existing child state," this is the wrong abstraction.
+- Because false maps to deprovision, callers must be deliberate about using predicates that can flap.
+- The package is intentionally tiny and does not add lifecycle policy beyond delegating to the child provisioner based on the predicate.

--- a/pkg/provisioners/remotecluster/README.md
+++ b/pkg/provisioners/remotecluster/README.md
@@ -1,0 +1,30 @@
+# pkg/provisioners/remotecluster
+
+## Intention
+
+`pkg/provisioners/remotecluster` is the provisioner adapter for switching execution into a remote cluster scope. It is not just a convenience wrapper for "run this on another cluster." It coordinates remote-cluster lifecycle, remote client construction, and child provisioner execution inside that remote scope.
+
+This package is one of the concrete places where the context-scoping model described in [pkg/client](../../client/README.md) becomes operational. Context here is not incidental metadata. It carries the active provisioning scope, and this package rewrites that scope so descendant provisioners operate against a remote cluster instead of the local control-plane view.
+
+In practice the package does three things:
+
+- ensures the remote cluster itself is created or registered when this wrapper owns that responsibility
+- builds a Kubernetes client for the remote kubeconfig and installs a new cluster scope into context
+- runs a child provisioner inside that remote scope, and later coordinates its teardown before the remote itself is removed
+
+## Invariants And Guard Rails
+
+- `ProvisionOn(child, ...)` returns a provisioner that executes the child inside a remote cluster scope, not in the caller's current cluster scope.
+- The remote scope is installed by creating a new `client.ClusterContext` and attaching it to context. Descendant provisioners are expected to treat that as the active provisioning target, consistent with the `pkg/client` context model.
+- When the `RemoteCluster` wrapper is marked as the controller, it owns remote cluster registration/lifecycle and ensures the remote exists before child provisioning proceeds.
+- Multiple child provisioners can share one `RemoteCluster` wrapper. The internal reference counting exists so that shared remote lifecycle is created once and torn down only after all registered children have completed.
+- `backgroundDeletion` is propagated through context to descendants. It is a policy signal that the remote is being discarded and some child cleanup may be safely skipped when the remote itself will be destroyed anyway.
+- The package is intended for reconciler-driven use. Child provisioners are expected to be idempotent and to yield quickly when they cannot make progress.
+
+## Caveats
+
+- This package mixes several concerns in one place: remote lifecycle ownership, remote client construction, provisioning-scope context switching, descendant policy propagation, and shared reference counting.
+- Correctness depends on usage discipline. Callers must consistently reuse the same `RemoteCluster` wrapper when multiple child provisioners are meant to share one remote lifecycle; otherwise the internal reference counting model does not describe reality.
+- The package is tightly coupled to the context-scoping model from [pkg/client](../../client/README.md). If that model is retired along with older CD/Argo-style provisioning flows, this package would likely need to shrink or be redesigned as well.
+- `backgroundDeletion` is a hidden context contract rather than an explicit method parameter on descendants, which makes behavior convenient but also less obvious at call sites.
+- During deprovision, failure to build the remote client due to `provisioners.ErrYield` is treated as a signal that child deprovisioning can be skipped because the remote is already effectively gone. That is a pragmatic lifecycle shortcut, not a universally safe remote-cleanup rule.

--- a/pkg/provisioners/resource/README.md
+++ b/pkg/provisioners/resource/README.md
@@ -1,0 +1,21 @@
+# pkg/provisioners/resource
+
+## Intention
+
+`pkg/provisioners/resource` is a legacy adapter that wraps a single Kubernetes `client.Object` in the provisioner interface. It is not a recommended abstraction for new provisioner code.
+
+This package exists mostly as historical convenience for trivial single-object cases, likely things such as namespaces, where someone wanted to fit a plain Kubernetes object into the provisioner lifecycle without writing a purpose-built provisioner.
+
+## Invariants And Guard Rails
+
+- New provisioner code should avoid this package. It is legacy compatibility, not the preferred model for resource management.
+- `Provision()` simply applies `controllerutil.CreateOrUpdate()` to the provided object using the scoped client from provisioner context.
+- `Deprovision()` simply issues a delete for the provided object, treats not-found as success, and otherwise returns `provisioners.ErrYield` so the broader reconcile loop can come back while deletion completes.
+- The object must already be fully prepared by the caller. This package does not generate, enrich, or orchestrate resource state beyond the raw create-or-update/delete operations.
+
+## Caveats
+
+- The type and constructor comments are stale and misleading. The implementation does not parse YAML manifests and does not invoke `kubectl`.
+- This package adds almost no real abstraction beyond adapting a single `client.Object` to the provisioner interface.
+- It is only suitable for extremely trivial single-object cases. Anything with meaningful generation logic, multiple resources, lifecycle coordination, or nontrivial semantics should have a purpose-built provisioner instead.
+- This is a deletion candidate once the remaining namespace lifecycle call sites, currently in the identity organization and project provisioners, are rewritten as explicit namespace create/delete handling rather than funneled through this adapter.

--- a/pkg/provisioners/serial/README.md
+++ b/pkg/provisioners/serial/README.md
@@ -1,0 +1,27 @@
+# pkg/provisioners/serial
+
+## Intention
+
+`pkg/provisioners/serial` is the ordered-composition combinator for provisioners whose lifecycle has ordering constraints. It is intended for reconciler-driven use, where child provisioners are expected to be idempotent and repeated reconcile passes are expected to drive the system toward convergence.
+
+This package does not try to provide transactional rollback. Its job is simpler:
+
+- provision children in dependency order
+- deprovision children in reverse dependency order
+- stop on the first error or yield and let the reconciler come back later
+
+## Invariants And Guard Rails
+
+- `Provision(ctx)` executes child provisioners in the declared order.
+- `Deprovision(ctx)` executes child provisioners in reverse order.
+- Execution stops on the first returned error, including `provisioners.ErrYield`.
+- This combinator assumes child provisioners are idempotent and safe to revisit on later reconcile passes.
+- The intended convergence model is controller-driven retry, not one-shot success.
+- Reverse-order deprovision assumes the same ordered child list is valid for both creation and teardown, with teardown simply needing the inverse traversal.
+
+## Caveats
+
+- This package preserves ordering only. It does not attempt rollback or compensation for earlier successful provision steps when a later child fails.
+- Partial progress is expected and acceptable in the reconciler model, but only because callers are expected to supply idempotent children and rely on automatic retries.
+- If the declared ordering is wrong, this combinator will faithfully enforce that wrong ordering.
+- Because execution stops on first error or yield, later children remain untouched until a future reconcile pass resumes progress.

--- a/pkg/provisioners/util/README.md
+++ b/pkg/provisioners/util/README.md
@@ -1,0 +1,25 @@
+# pkg/provisioners/util
+
+## Intention
+
+`pkg/provisioners/util` is a small helper package for common provisioner chores. It is not a broad abstraction layer for provisioners, and it only groups together a few pieces that ended up being reused across multiple provisioner implementations.
+
+The package currently covers two narrow themes:
+
+- control-plane scheduling fragments used when provisioners need to render workload placement policy into Helm values or similar configuration
+- a couple of generic helper functions used by provisioners for namespace lookup and configuration change detection
+
+## Invariants And Guard Rails
+
+- The control-plane scheduling helpers are intentionally untyped. They return `[]any` and `map[string]any` because they are meant to feed rendered configuration and chart values, not to construct typed Kubernetes API objects directly in Go.
+- `ControlPlaneTolerations()` and `ControlPlaneNodeSelector()` define the repository's standard scheduling fragments for forcing workloads onto control-plane nodes when managed-service placement requires that.
+- `ControlPlaneInitTolerations()` adds the extra bootstrap-time tolerations needed for components such as CNIs or cloud-provider integrations that must run before the cluster is fully initialized.
+- `GetResourceNamespace()` is the common helper for provisioner paths that expect a label selector to resolve to exactly one namespace.
+- `GetConfigurationHash()` is the common helper for deriving a stable hash from rendered configuration so callers can trigger restarts for workloads that do not react cleanly to configuration changes.
+
+## Caveats
+
+- The package boundary is mixed. Scheduling policy fragments, namespace lookup, and configuration hashing are only loosely related.
+- The control-plane scheduling helpers encode repository policy, not universal Kubernetes best practice. They are appropriate where the platform deliberately wants managed components on control-plane nodes, including scale-to-zero worker scenarios.
+- `GetResourceNamespace()` treats anything other than exactly one matching namespace as an error. That is convenient for callers that rely on uniqueness, but it means the helper is only valid where the label contract is already strong.
+- `GetConfigurationHash()` is operational workaround logic. It exists because some managed applications do not respond properly to configuration changes and need a forced restart signal.

--- a/pkg/server/README.md
+++ b/pkg/server/README.md
@@ -1,0 +1,41 @@
+# pkg/server
+
+## Intention
+
+`pkg/server` is the shared API-server support layer for platform services. It is not a complete server framework by itself, but it collects the common building blocks that turn generated OpenAPI handlers into the platform's standard HTTP behavior.
+
+At the top level, this directory brings together:
+
+- API-boundary conversion between Kubernetes resources and shared API envelopes
+- the canonical user-facing error surface for normal APIs
+- the canonical shared middleware stack for request processing
+- a first-cut in-process saga helper for best-effort multi-step rollback
+- a small set of handler-adjacent utility functions
+
+This package family is tightly connected to the shared OpenAPI substrate documented in [pkg/openapi](../openapi/README.md), because route resolution, schema-driven middleware behavior, and common error responses all depend on that contract.
+
+## Invariants And Guard Rails
+
+- `pkg/server` is for common API-server behavior across services, not for service-specific handler logic, auth policy, or domain-owned middleware.
+- The shared pieces here are intended to preserve one platform-wide API experience:
+  - common request/response shaping
+  - common route/schema interpretation
+  - common middleware ordering expectations
+  - common user-facing error structure
+- Service packages are expected to build on these lower layers rather than reimplementing them ad hoc, while still adding their own domain-specific handlers and middleware where appropriate.
+- The top-level story here is cooperative composition, not a single monolithic abstraction. The subpackages are the real units of behavior.
+
+## Package Map
+
+- [conversion](./conversion/README.md): shared generic conversion layer for common resource metadata, status, and tag translation between Kubernetes objects and API envelopes.
+- [errors](./errors/README.md): canonical user-facing API error contract and response writer for normal APIs, plus propagation helpers for remote API failures.
+- [middleware](./middleware/README.md): canonical shared middleware stack for platform APIs, including route resolution, CORS, logging, tracing, timeout, and response capture support.
+- [saga](./saga/README.md): synchronous in-process best-effort rollback coordinator for multi-step handler workflows.
+- [util](./util/README.md): small server-boundary helper bucket for response writing, request-body decoding, ownership concealment checks, and tag parsing.
+
+## Caveats
+
+- `pkg/server` is still a family of helpers rather than a clean, unified server framework. The subpackages are related by usage in service APIs more than by one elegant abstraction boundary.
+- Some of the most important behavior here is context- and ordering-sensitive, especially in [middleware](./middleware/README.md) and [errors](./errors/README.md).
+- The server layer depends heavily on the shared OpenAPI/runtime contract. If route generation or schema usage changes materially, several subpackages here would need to move in lock step.
+- Not every subpackage is equally clean. `saga` is deliberately first-cut and non-durable, while `util` is a pragmatic helper bucket rather than a principled design.

--- a/pkg/server/conversion/README.md
+++ b/pkg/server/conversion/README.md
@@ -1,0 +1,32 @@
+# pkg/server/conversion
+
+## Intention
+
+`pkg/server/conversion` is the canonical shared conversion layer for the generic part of API handler conversion. Service handlers still own type-specific conversion for their domain objects, but they should build the common resource envelope through this package rather than reimplementing shared metadata, status, scoping, and tag handling locally.
+
+This package bridges the repository's shared metadata vocabulary from [pkg/constants](../constants/README.md) and shared API resource types from [pkg/openapi](../openapi/README.md) into concrete handler conversion code.
+
+It combines four closely related responsibilities:
+
+- projecting shared Kubernetes object metadata into common API resource metadata for read paths
+- translating common internal provisioning and health condition state into public API status enums
+- assembling and mutating shared Kubernetes object metadata for write paths
+- converting shared tag representations between Kubernetes and OpenAPI forms, and logging update patches for debugging
+
+## Invariants And Guard Rails
+
+- This package covers the generic conversion layer only. Service-specific converters must still handle domain fields and resource-specific semantics on top.
+- `ResourceReadMetadata`, `OrganizationScopedResourceReadMetadata`, and `ProjectScopedResourceReadMetadata` are the standard way to build the shared API resource envelope from Kubernetes objects.
+- `NewObjectMetadata` is the standard base path for constructing shared object metadata from API write metadata when a service needs to create a new Kubernetes resource. Callers are expected to layer scoping and resource-specific labels on top with the builder methods.
+- `UpdateObjectMetadata` is the common path for applying shared metadata mutation behavior on update, including the modified timestamp annotation. It is intentionally composable and callers commonly provide additional service-specific mutators on top of the generic behavior.
+- Provisioning and health status mapping here is repository-specific policy based on Unikorn status conditions. Callers should not improvise their own generic status mapping for the same resource envelope.
+- Deletion takes precedence for provisioning state. If a resource is being deleted, the public provisioning status is reported as `deprovisioning` immediately.
+- Tag conversion helpers here are the shared bridge between Kubernetes tag lists and OpenAPI tag lists. Type-specific converters should reuse them rather than duplicating field-by-field translation.
+
+## Caveats
+
+- The package centralizes generic conversion logic, but it still mixes read projection, write metadata assembly, tag translation, and update logging in one place.
+- The scoped read-metadata helpers use JSON marshal and unmarshal to copy the shared base metadata into larger generated OpenAPI structs. That is pragmatic generated-type glue rather than an especially elegant conversion model.
+- Generic metadata extraction is intentionally tolerant. Missing labels or annotations usually degrade to empty or absent API fields rather than producing hard conversion failures, which means scoping or attribution data can disappear from the outward API view without this layer rejecting the conversion.
+- The status mapping is only as expressive as the shared condition vocabulary. Resources with richer or different lifecycle semantics still need service-specific conversion logic around this generic layer.
+- `LogUpdate` is a debugging aid that logs a merge-patch-style diff of the resource update. It is useful for visibility, but it is not a patch application mechanism or a general audit system.

--- a/pkg/server/errors/README.md
+++ b/pkg/server/errors/README.md
@@ -1,0 +1,34 @@
+# pkg/server/errors
+
+## Intention
+
+`pkg/server/errors` defines the canonical user-facing error surface for the platform's APIs. It is the core error type that handlers and middleware use to turn failures into the structured JSON error responses returned to clients on almost every API call.
+
+The wire format is inspired by OAuth2 error semantics, but it is not limited to OAuth2 endpoints. The platform extends that model so the same terse-code-plus-description shape can be used consistently across other APIs as well.
+
+This package combines three closely related responsibilities:
+
+- constructing platform API errors with HTTP status, terse error code, user-facing description, optional headers, and internal logging detail
+- writing those errors to HTTP responses, including the trace ID that clients can use when reporting failures
+- propagating and normalizing API errors across service-to-service OpenAPI calls so one service can surface another service's failure using the same local error model
+
+OAuth2 endpoints are the partial exception rather than the opposite. They still use this package heavily, but some of their wire semantics are constrained by the formal OAuth2 and related specifications rather than only by the platform's broader API conventions.
+
+## Invariants And Guard Rails
+
+- This is the canonical platform API error type for normal APIs, not just an internal helper.
+- Errors here are user-facing contract objects. Their HTTP status, terse code, description, and header behavior are part of the API surface clients observe.
+- The error shape is OAuth2-inspired but intentionally reusable across non-OAuth2 APIs.
+- `WithError()` and `WithValues()` are for internal logging context. They augment server-side observability and must not be treated as additional client-visible payload.
+- `Write()` is responsible for emitting the standard JSON error body and, when trace context is present, the trace ID clients use for support correlation.
+- Constructors such as `HTTPNotFound`, `HTTPConflict`, `OAuth2InvalidRequest`, `AccessDenied`, and related helpers are the standard way to create common API failure classes.
+- `HandleError()` is the main normalization point for handlers and middleware that need to surface arbitrary failures through the platform error contract.
+- `PropagateError()` is the main cross-service adapter for generated OpenAPI client response types.
+- `FromOpenAPIError()` is the narrower helper for paths that already hold a decoded `openapi.Error` payload and need to rebuild the local error model from it.
+
+## Caveats
+
+- The package is the platform's generalized OAuth2-inspired error model, while pure OAuth2 and related authentication flows remain the constrained special case where formal RFC wire semantics still apply.
+- `PropagateError()` is a pragmatic workaround for how `oapi-codegen` generated `*WithResponse` client types expose per-status response payloads through fields such as `JSON400`, `JSON404`, and similar. It relies on reflection because the generator does not provide a cleaner typed error path.
+- The package mixes user-facing wire contract, logging policy, header encoding, and service-to-service error propagation in one place. That is practical, but it makes the boundary broader than a pure response-type package.
+- If an error is created or propagated poorly, the package will still emit a client response, but the quality of support/debugging information depends heavily on callers attaching useful internal context with `WithError()` and `WithValues()`.

--- a/pkg/server/middleware/README.md
+++ b/pkg/server/middleware/README.md
@@ -1,0 +1,29 @@
+# pkg/server/middleware
+
+## Intention
+
+`pkg/server/middleware` provides the canonical shared middleware stack for platform APIs. It contains the common request-pipeline components that platform services are expected to compose before adding any service-specific middleware of their own.
+
+The subpackages are cooperative and order-sensitive rather than interchangeable. They establish trace context and correlated logging context, resolve OpenAPI route metadata, implement schema-driven CORS behavior, and add request-context timeouts. The root package also provides generic response-capture helpers used by tests and by middleware patterns that need to inspect responses.
+
+This package does not try to own every middleware concern in the platform. Service-specific middleware still belongs with the service that owns the behavior, for example identity-specific authentication and authorization layers.
+
+For the OpenAPI route-resolution contract that this stack depends on, see [pkg/openapi/README.md](/home/simon/src/github.com/unikorn-cloud/core/pkg/openapi/README.md).
+
+## Invariants And Guard Rails
+
+- This is the canonical shared middleware stack for platform APIs, not a miscellaneous collection of unrelated HTTP helpers.
+- Middleware in this directory is designed to cooperate as a request pipeline. Ordering is part of the contract.
+- `opentelemetry` must establish trace context early because the trace ID is a customer-facing correlation handle for failures and a primary way to connect support requests to logs and telemetry.
+- `logging` depends on request context and response metrics to produce useful request and response records without exposing obviously sensitive headers.
+- `routeresolver` is load-bearing shared middleware. It resolves OpenAPI route metadata once and stashes it in context for downstream consumers. See [pkg/openapi/README.md](/home/simon/src/github.com/unikorn-cloud/core/pkg/openapi/README.md).
+- `cors` depends on that resolved route information, especially for emulated `OPTIONS` handling.
+- `timeout` adds request-context deadlines. Downstream handlers and middleware must respect context cancellation for it to be effective.
+- Service packages may add their own middleware, but domain-specific concerns should live with the package that owns the behavior rather than being pushed into this shared stack.
+
+## Caveats
+
+- The root package boundary is slightly awkward: `Capture` is generic response-capture infrastructure, while most of the real behavior lives in subpackages.
+- Middleware ordering is not optional. Reordering pieces such as route resolution and CORS can change behavior or break schema-driven handling.
+- `timeout` is intentionally simple context wrapping, not a full response-timeout or request-abort framework. Work that ignores context can outlive the intended deadline.
+- The canonical shared stack is not exhaustive. Service-specific packages will still define additional middleware where the behavior is not platform-generic.

--- a/pkg/server/saga/README.md
+++ b/pkg/server/saga/README.md
@@ -1,0 +1,25 @@
+# pkg/server/saga
+
+## Intention
+
+`pkg/server/saga` provides a deliberately small in-process saga runner for multi-step server workflows that need best-effort cleanup on failure.
+
+Its purpose is to give handlers a common rollback pattern for synchronous operations that perform several state-changing steps, such as quota allocation followed by resource creation. Instead of open-coding partial rollback in every handler, callers describe an ordered list of forward actions and optional compensation actions.
+
+This package is intentionally a first-cut implementation. The goal is to get server workflows onto a shared best-effort cleanup model, not to provide durable orchestration, reliable recovery, or distributed saga semantics.
+
+## Invariants And Guard Rails
+
+- This package is for synchronous in-process rollback coordination, not for durable workflow orchestration.
+- A saga handler defines an ordered list of actions. `Run()` executes them in order on the forward path.
+- If an action fails, previously completed actions are compensated in reverse order when a compensation function is defined.
+- The original action failure is the error returned to the caller, even if a later compensation step also fails.
+- Actions and compensations are typically bound receivers so saga steps can share state accumulated during the workflow.
+- Compensation is optional per action. Callers must be explicit about which state changes can and cannot be unwound.
+
+## Caveats
+
+- Cleanup is best-effort only. There is no durable saga log, resumability, retry policy, or asynchronous recovery.
+- If a compensation step fails, the package logs the compensation failure and returns the original action error. Recovery may therefore be incomplete and require manual cleanup.
+- The implementation is deliberately minimal. It does not attempt to classify transient versus terminal errors or make policy decisions about retries.
+- This package does not make a distributed operation atomic. It only provides a structured local pattern for attempting rollback after partial failure.

--- a/pkg/server/util/README.md
+++ b/pkg/server/util/README.md
@@ -1,0 +1,29 @@
+# pkg/server/util
+
+## Intention
+
+`pkg/server/util` is a pragmatic collection of small server-handler helpers that sit at the API boundary and are reused across services.
+
+These helpers are close to request and response handling rather than core domain logic. Today they cover three main jobs:
+
+- writing common response bodies such as JSON and octet-stream payloads
+- decoding request-body or query-adjacent data into internal representations
+- asserting post-lookup ownership and visibility rules for directly fetched resources
+
+The ownership assertions are the most important non-obvious part of the package. They are not RBAC policy engines. They are concealment helpers for direct object lookup paths where a handler fetches by resource ID first for efficiency, then checks whether the result is actually in the caller's allowed organization or project scope. If the scope does not match, the helper returns a 404 so the API does not leak the existence of an out-of-scope resource.
+
+## Invariants And Guard Rails
+
+- This package is for small server-boundary helpers that are generic across services, not for core business logic.
+- `AssertOrganizationOwnership` and `AssertProjectOwnership` are post-lookup scope assertions, not substitutes for RBAC authorization decisions.
+- Those ownership assertions exist specifically to preserve "not found" semantics after direct resource lookup when revealing existence would leak information across scopes.
+- Response helpers here are intentionally thin wrappers. They do not replace schema validation, business logic, or higher-level error shaping.
+- `ReadJSONBody` is intended for paths where earlier OpenAPI schema validation in middleware should already have established the expected body shape. A decode failure at this stage usually indicates a mismatch between that earlier validation contract and later handler expectations.
+- Tag decoding helpers translate API-facing OpenAPI parameter forms into internal tag structures. They should stay aligned with the shared OpenAPI contract rather than inventing independent parsing rules.
+
+## Caveats
+
+- The package is useful but not conceptually tight. Response encoding, ownership concealment, and tag decoding are only loosely related beyond all being handler-adjacent concerns.
+- `rbac.go` is a misleading filename if read literally. The code does not make authorization decisions; it performs post-lookup ownership assertions with information-hiding behavior.
+- The response helpers are intentionally minimal and can silently do very little beyond logging if marshaling or writing fails. They are convenience helpers, not a full response abstraction layer.
+- If this package grows much further, it may want splitting by concern rather than continuing as a generic server utility bucket.

--- a/pkg/util/README.md
+++ b/pkg/util/README.md
@@ -1,0 +1,28 @@
+# pkg/util
+
+## Intention
+
+`pkg/util` is a legacy miscellaneous bucket. It does not represent one coherent abstraction. It contains a small set of cross-cutting helpers and tiny shared types that historically did not get better homes.
+
+The main things still living here are:
+
+- `GenerateResourceID()` for generating Kubernetes-safe random resource IDs
+- `ServiceDescriptor` for passing common service/controller identity metadata such as name, version, and revision
+- `GetNATPrefix()` for discovering the process's internet-facing address and expressing it as a `/32` so managed cluster firewall rules can allow control-plane access
+- `K8SAPITester` and `DefaultK8SAPITester` for a narrow kubeconfig connectivity check seam used by CD-layer code
+- `Keys()` as a small map-key helper that is now effectively obsolete
+
+## Invariants And Guard Rails
+
+- This package should stay small. New code should not treat `pkg/util` as the default home for unrelated helper functions just because they feel broadly reusable.
+- `GenerateResourceID()` is the shared helper for generating random Kubernetes resource IDs that satisfy the repository's naming expectations.
+- `ServiceDescriptor` is the shared identity payload used where services, controllers, or cross-service clients need a common `name/version/revision` description.
+- `GetNATPrefix()` is a pragmatic helper for the managed-cluster access model. Its job is to discover the control plane's egress address so firewall rules can allow access back into managed clusters.
+- `K8SAPITester` is a very limited integration seam for testing whether a kubeconfig can actually reach a Kubernetes API. It is not a broad connectivity abstraction and is mainly relevant to the CD-layer reachability check path.
+
+## Caveats
+
+- The package boundary is weak. These helpers live together mostly because of history, not because they belong to one design.
+- `Keys()` is effectively superseded by `maps.Keys` and should be treated as a cleanup candidate rather than something new code should continue to spread. It can be removed once the remaining live call sites are migrated.
+- `GetNATPrefix()` depends on an external internet service, memoizes the result globally, and assumes one observed egress address is the right process-wide answer. That is pragmatic operational baggage, not a cleanly modeled networking contract.
+- `K8SAPITester` and its default implementation are specific enough that they would make more architectural sense closer to the code that owns kubeconfig validation.

--- a/pkg/util/cache/README.md
+++ b/pkg/util/cache/README.md
@@ -1,0 +1,35 @@
+# pkg/util/cache
+
+## Intention
+
+`pkg/util/cache` is not one coherent cache abstraction. It is a utility package that currently contains several cache strategies with different cost and correctness tradeoffs.
+
+The main reason this package exists today is `RefreshAheadCache`, which is the repository's higher-performance cache for indexed sets of resources where request-path refresh latency and visibility guarantees matter. The smaller `TimeoutCache` and `LRUExpireCache` helpers are still live and useful, but they solve simpler problems and do not share the same model.
+
+The current cache families are:
+
+- `TimeoutCache` for a single cached value with a timeout and explicit invalidation
+- `LRUExpireCache` for typed LRU+TTL storage over `apimachinery`'s cache, with defensive deep-copy semantics by default
+- `RefreshAheadCache` for background-refreshed indexed snapshots, synchronous invalidation, epoch-based snapshot identity, and local write-through overlay behavior
+
+## Invariants And Guard Rails
+
+- Choose the cache type for its operational model, not just for convenience. These types do not implement interchangeable caching semantics.
+- `TimeoutCache` is the simple TTL/invalidate model. Once the value expires or is invalidated, the next caller that needs fresh data must pay the refresh cost.
+- `RefreshAheadCache` exists to avoid pushing that refresh cost onto normal read paths. `Run()` performs an initial blocking load, then keeps the cache warm with periodic refresh.
+- `RefreshAheadCache.Invalidate()` is deliberately synchronous. On success, callers can assume the refreshed data is visible in that cache instance before control returns.
+- `RefreshAheadCache` is designed around uniquely indexed sets of resources and a single cache instance. Its correctness model is not a distributed coherence protocol.
+- `RefreshAheadCache` local write-through helpers rely on a strict usage rule: the corresponding backend write must already have committed synchronously and atomically before the cache is updated locally.
+- `RefreshAheadCache` epochs describe the identity of the visible cache snapshot. Callers may memoize derived work against an epoch and reuse it until that epoch changes.
+- `LRUExpireCache` defaults to deep-copy behavior to reduce accidental mutation of cached values. `ZeroCopy()` is an explicit tradeoff that gives speed back to the caller at the cost of safety.
+
+## Caveats
+
+- The package boundary is broad and a little ugly. `TimeoutCache`, `LRUExpireCache`, and `RefreshAheadCache` are related only in the loose sense that they all cache things.
+- `TimeoutCache` is simple but leaves refresh ownership with whoever reads after expiry or invalidation. That pushes refresh latency onto the unlucky reader, which is the main problem `RefreshAheadCache` is intended to solve for hotter read paths.
+- `RefreshAheadCache` is sophisticated enough that correctness depends on usage discipline, not just on calling the exported methods. The overlay model only protects local writes against refreshes already in flight; it is not a long-lived reconciliation layer.
+- `RefreshAheadCache` assumes a single writer-view per cache instance. If one process writes and another process reads through a different cache instance, read-your-writes is not guaranteed.
+- `RefreshAheadCache` is optimized for pointer-based zero-copy reads and snapshot reuse. That helps performance, but it means callers need to understand that individual items are shared references, not defensive deep copies.
+- `Invalidate()` only becomes operational after `Run()` has initialized the refresh loop. Calling it before startup can block indefinitely waiting for a refresh channel that does not exist yet. This is a real lifecycle hazard, not a graceful mode.
+- `LRUExpireCache.Add()` and `Get()` silently degrade on deep-copy failure by dropping the value or returning a miss.
+- `TimeoutCache.Invalidate()` currently mutates cache state without taking the same lock used by `Get()` and `Set()`. That is an implementation wart, not a design feature.

--- a/pkg/util/retry/README.md
+++ b/pkg/util/retry/README.md
@@ -1,0 +1,28 @@
+# pkg/util/retry
+
+## Intention
+
+`pkg/util/retry` is a minimal polling-style retry helper. It is not a general retry-policy framework. Its job is to keep retrying a callback until it succeeds or until the caller's context is cancelled.
+
+This package exists largely for historical convenience. It is useful for simple standalone waits and short polling loops, but it is not the platform's preferred model for controller reconciliation progress.
+
+It currently provides:
+
+- `Forever()` to construct a retrier with a fixed one-second retry period
+- `Do()` and `DoWithContext()` to run the callback immediately and then keep retrying until success or cancellation
+- `retry.Error` to preserve both the context cancellation error and the last callback failure when the loop exits because the context ended
+
+## Invariants And Guard Rails
+
+- The callback is invoked immediately before any waiting occurs.
+- If the callback continues to fail, retries happen every second until success or context cancellation.
+- `Do()` uses `context.TODO()`. `DoWithContext()` is the path to use when cancellation or timeout semantics matter.
+- On cancellation, the returned `retry.Error` preserves both why the loop stopped and what the callback was still failing with.
+- This helper is acceptable for a small number of simple blocking poll loops where returning control to a framework is not the right model. It should not be treated as the default retry primitive for new workflow code.
+
+## Caveats
+
+- The fixed one-second retry period is historical simplicity, not a carefully tuned repository-wide retry policy.
+- This package does not provide backoff, jitter, retry budgets, selective retry by error type, or observability hooks.
+- This is not the preferred primitive for controller-runtime reconciler progress. In reconciler code, the platform generally prefers yielding back to controller-runtime and using requeue/retry semantics so reconciliation stays non-blocking and fair.
+- Using this helper inside long-running reconciliation paths can work against the fairness and controlled-retry behavior provided elsewhere in the platform.


### PR DESCRIPTION
Document the shared core package structure with linked README files that explain intent, invariants, caveats, and cleanup directions for the main runtime and API layers.

This adds coverage for package-level rollups such as pkg/, pkg/apis/, pkg/server/, pkg/provisioners/, and pkg/manager/, plus foundational leaf packages across client, constants, errors, options, openapi, messaging, util, and the main server and provisioner layers.

The new READMEs are meant to be a navigable knowledge graph for humans and AI agents so they can follow the real contracts in this repository without reverse-engineering everything from code. They are intentionally candid about historical baggage, legacy in-tree CD coupling, cleanup targets, and deletion candidates.

Also link the repo root README to pkg/README.md and tighten several root README descriptions so they match the actual reconcile, context, and provisioner semantics described in the new package graph.
