### PR TITLE
Implement per-service automated tagging and nightly releases

### DIFF
--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -1,0 +1,61 @@
+name: Cleanup Nightlies
+on:
+  schedule:
+  - cron: '0 4 * * *'
+  workflow_dispatch:
+    inputs:
+      ttl_days:
+        description: 'Delete nightly builds older than this many days'
+        required: false
+        default: '7'
+        type: string
+permissions:
+  contents: write
+  packages: write
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
+    - name: Delete expired nightlies
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        TTL_DAYS: ${{ inputs.ttl_days || '7' }}
+      run: |
+        OWNER=$(cut -d'/' -f1 <<< "$GITHUB_REPOSITORY")
+        REPO=$(cut -d'/' -f2 <<< "$GITHUB_REPOSITORY")
+        CHART_NAME=$(sed 's/^uni-//' <<< "$REPO")
+        CHART_PACKAGE_NAME=$(grep '^name:' "charts/${CHART_NAME}/Chart.yaml" | awk '{print $2}')
+        CHART_PKG="charts-nightly%2F${CHART_PACKAGE_NAME}"
+
+        CUTOFF=$(date -u -d "${TTL_DAYS} days ago" +%Y%m%d%H%M%S)
+        echo "Cutoff: ${CUTOFF} (TTL: ${TTL_DAYS} days)"
+
+        while read -r TAG; do
+          TIMESTAMP=$(sed 's/v0\.0\.0-\([0-9]\{14\}\)-.*/\1/' <<< "$TAG")
+          [[ "$TIMESTAMP" =~ ^[0-9]{14}$ ]] || continue
+          [[ "$TIMESTAMP" < "$CUTOFF" ]] || continue
+
+          CHART_VERSION="${TAG#v}"
+          echo "Expiring ${TAG}"
+
+          # Delete OCI chart package version
+          ID=$(gh api "/orgs/${OWNER}/packages/container/${CHART_PKG}/versions" --paginate \
+            --jq ".[] | select((.metadata.container.tags // [])[] == \"${CHART_VERSION}\") | .id" \
+            2>/dev/null | head -1)
+          if [[ -n "$ID" ]]; then
+            gh api -X DELETE "/orgs/${OWNER}/packages/container/${CHART_PKG}/versions/${ID}" \
+              && echo "  ✓ chart" || echo "  ✗ chart (will retry next run)"
+          fi
+
+          # Delete git tag last — if artifact deletion failed above, the tag
+          # remains and the next run will retry it before attempting this again.
+          gh api -X DELETE "/repos/${OWNER}/${REPO}/git/refs/tags/${TAG}" \
+            && echo "  ✓ git tag" || echo "  ✗ git tag"
+
+        done < <(gh api "/repos/${OWNER}/${REPO}/git/refs/tags" --paginate \
+          --jq '.[].ref | select(test("refs/tags/v0\\.0\\.0-"))' \
+          | sed 's|refs/tags/||')

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,0 +1,83 @@
+name: Nightly
+on:
+  schedule:
+  - cron: '0 2 * * *'
+  workflow_dispatch: {}
+# Queue concurrent runs rather than cancelling them. cancel-in-progress: true
+# would risk killing a run between chart publish and tag push, leaving a
+# published chart with no corresponding tag — the opposite of the safety
+# invariant this workflow is designed to maintain.
+concurrency:
+  group: nightly
+  cancel-in-progress: false
+permissions:
+  contents: write
+  packages: write
+jobs:
+  Nightly:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
+    - name: Install Helm
+      uses: azure/setup-helm@v4
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Configure Git
+      run: |
+        git config user.name "$GITHUB_ACTOR"
+        git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+    - name: Compute tag
+      run: |
+        TAG="v0.0.0-$(date -u +%Y%m%d%H%M%S)-$(git rev-parse --short=12 HEAD)"
+        CHART_VERSION="${TAG#v}"
+        # Derives the primary service chart from the repo name. Ancillary charts
+        # in this repo (e.g. charts/pact-broker) are intentionally excluded from
+        # nightly automation and are not expected to carry the 0.0.0 sentinel.
+        REPO=$(cut -d'/' -f2 <<< "$GITHUB_REPOSITORY")
+        CHART_NAME=$(sed 's/^uni-//' <<< "$REPO")
+        [[ -d "charts/${CHART_NAME}" ]] || {
+          echo "ERROR: charts/${CHART_NAME} not found — repo name may not match chart directory"
+          exit 1
+        }
+        # helm package names its output from Chart.yaml's name: field, not the
+        # directory name. Extract it explicitly so the push step references the
+        # correct filename rather than reconstructing it from the directory name.
+        CHART_PACKAGE_NAME=$(grep '^name:' "charts/${CHART_NAME}/Chart.yaml" | awk '{print $2}')
+        [[ -n "${CHART_PACKAGE_NAME}" ]] || {
+          echo "ERROR: could not extract chart name from charts/${CHART_NAME}/Chart.yaml"
+          exit 1
+        }
+        echo "TAG=${TAG}" >> $GITHUB_ENV
+        echo "CHART_VERSION=${CHART_VERSION}" >> $GITHUB_ENV
+        echo "CHART_NAME=${CHART_NAME}" >> $GITHUB_ENV
+        echo "CHART_PACKAGE_NAME=${CHART_PACKAGE_NAME}" >> $GITHUB_ENV
+    - name: Log in to GHCR
+      run: |
+        echo "$GITHUB_TOKEN" | helm registry login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Update chart dependencies
+      run: helm dependency update "charts/${CHART_NAME}"
+    - name: Package and push chart
+      run: |
+        helm package "charts/${CHART_NAME}" --version "${CHART_VERSION}" --app-version "${CHART_VERSION}"
+        helm push "${CHART_PACKAGE_NAME}-${CHART_VERSION}.tgz" "oci://ghcr.io/nscaledev/charts-nightly"
+    # Tag is pushed after a successful chart publish so a failed publish does
+    # not leave a dangling tag pointing at a commit with no chart artifact.
+    - name: Push tag
+      run: |
+        git tag "${TAG}"
+        git push origin "${TAG}"
+    - name: Notify Slack on failure
+      if: failure()
+      uses: slackapi/slack-github-action@v2
+      with:
+        webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+        webhook-type: incoming-webhook
+        payload: |
+          {
+            "text": ":red_circle: *Nightly build failed* — `${{ github.repository }}`. I'll be back.\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          }

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,7 +4,10 @@ on:
     branches-ignore:
     - '**'
     tags:
-    - '*'
+    # Exclude nightly pseudo-version tags (v0.0.0-*) precisely rather than
+    # using v[1-9]*, which would silently drop legitimate v0.x.y releases.
+    - 'v*'
+    - '!v0.0.0-*'
 permissions:
   contents: write
   packages: write
@@ -13,17 +16,62 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - name: Install Helm
-      uses: azure/setup-helm@v4
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Configure Git
       run: |
         git config user.name "$GITHUB_ACTOR"
         git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+    - name: Validate tag
+      run: |
+        TAG="${GITHUB_REF_NAME}"
+        # Strict semver: vX.Y.Z or vX.Y.Z-pre (alphanumeric, dots, hyphens only).
+        # This rejects build metadata (+), path traversal, sed metacharacters, and
+        # anything else that could corrupt the sed interpolation in the patch step.
+        if [[ ! "${TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9._-]+)?$ ]]; then
+          echo "ERROR: tag '${TAG}' is not valid semver (expected vX.Y.Z or vX.Y.Z-pre)"
+          exit 1
+        fi
+        if [[ "${TAG}" == "v0.0.0" || "${TAG}" == v0.0.0-* ]]; then
+          echo "ERROR: tags matching v0.0.0 or v0.0.0-* are reserved for nightly builds"
+          exit 1
+        fi
+    - name: Derive chart version
+      run: |
+        CHART_VERSION="${GITHUB_REF_NAME#v}"
+        REPO=$(cut -d'/' -f2 <<< "$GITHUB_REPOSITORY")
+        CHART_NAME=$(sed 's/^uni-//' <<< "$REPO")
+        [[ -d "charts/${CHART_NAME}" ]] || {
+          echo "ERROR: charts/${CHART_NAME} not found — repo name may not match chart directory"
+          exit 1
+        }
+        echo "CHART_VERSION=${CHART_VERSION}" >> $GITHUB_ENV
+        echo "CHART_NAME=${CHART_NAME}" >> $GITHUB_ENV
+    - name: Patch Chart.yaml sentinel
+      run: |
+        # uni-chart-release-action uses `cr package` which reads version directly
+        # from Chart.yaml and has no --version override flag. The sentinel must be
+        # patched on disk before the action runs. Contrast with nightly.yaml, which
+        # bypasses Chart.yaml entirely via `helm package --version`.
+        # sed on YAML is fragile against whitespace drift or reformatting, but
+        # avoids a yq install step. The anchored regex (^version: 0\.0\.0$) is
+        # tight enough that normal edits won't misfire. The grep guards below
+        # catch the failure case explicitly rather than letting it pass silently.
+        sed -i "s/^version: 0\.0\.0$/version: ${CHART_VERSION}/" "charts/${CHART_NAME}/Chart.yaml"
+        sed -i "s/^appVersion: 0\.0\.0$/appVersion: ${CHART_VERSION}/" "charts/${CHART_NAME}/Chart.yaml"
+        # Extract top-level fields only (no leading whitespace) to avoid false
+        # positives from dependency version lines that share the same value.
+        PATCHED_VERSION=$(grep '^version:' "charts/${CHART_NAME}/Chart.yaml" | awk '{print $2}')
+        PATCHED_APP_VERSION=$(grep '^appVersion:' "charts/${CHART_NAME}/Chart.yaml" | awk '{print $2}')
+        [[ "${PATCHED_VERSION}" == "${CHART_VERSION}" ]] || {
+          echo "ERROR: Chart.yaml version patch failed — sentinel was not present"
+          exit 1
+        }
+        [[ "${PATCHED_APP_VERSION}" == "${CHART_VERSION}" ]] || {
+          echo "ERROR: Chart.yaml appVersion patch failed — sentinel was not present"
+          exit 1
+        }
     - name: Release Helm Chart
       uses: nscaledev/uni-chart-release-action@v2
       env:

--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -4,8 +4,9 @@ description: A Helm chart for deploying Unikorn Core
 
 type: application
 
-version: 1.16.1
-appVersion: 1.16.1
+# sentinel: patched at release time by release.yaml; overridden by --version for nightly builds
+version: 0.0.0
+appVersion: 0.0.0
 
 icon: https://assets.unikorn-cloud.org/images/logos/dark-on-light/icon.svg
 


### PR DESCRIPTION
The uni-release policy requires a nightly assembler that deploys the
latest passing main of every service to dev. This was blocked by the
requirement for a human to bump and merge Chart.yaml version changes
before a tag could be pushed. This change removes that gate.

Chart.yaml version/appVersion are set to a sentinel (0.0.0) that is
never published directly. Production releases patch it with sed at
runtime; nightly builds bypass it entirely via helm package --version.

release.yaml is updated to exclude nightly pseudo-version tags using a
precise negation filter (!v0.0.0-*) rather than v[1-9]*, which would
silently drop legitimate v0.x.y releases. Both sed patches are verified
with grep so a missing sentinel fails loudly rather than publishing a
chart at version 0.0.0. CHART_NAME derivation is validated against the
filesystem so a repo/chart naming divergence gives a clear error. The
redundant Install Helm step is removed — uni-chart-release-action uses
chart-releaser (cr), not Helm.

nightly.yaml is a new workflow that runs at 02:00 UTC and on
workflow_dispatch. It computes a Go pseudo-version tag
(v0.0.0-YYYYMMDDHHMMSS-<12-char-sha>), publishes the chart to
oci://ghcr.io/nscaledev/charts-nightly, then pushes the tag. The tag
is pushed last so a failed chart publish never leaves a dangling tag
with no corresponding artifact. Concurrency is restricted to one run at
a time so a workflow_dispatch cannot race with the cron schedule. A
Slack webhook notification fires on any step failure.

cleanup.yaml is a new workflow that runs daily at 04:00 UTC and deletes
nightly builds older than TTL_DAYS (default 7). For each expired tag it
removes the OCI chart from charts-nightly and then the git tag — in
that order so a failed chart deletion leaves the tag in place for the
next run to retry. TTL is overridable via workflow_dispatch for manual
sweeps. (Core has no Docker image artifact, so image cleanup is omitted
unlike the ui repo equivalent.)