### PR TITLE
fix(server/util): map JSON decode errors to 400 instead of 500

### DIFF
--- a/pkg/server/util/json.go
+++ b/pkg/server/util/json.go
@@ -23,6 +23,8 @@ import (
 	"io"
 	"net/http"
 
+	servererrors "github.com/unikorn-cloud/core/pkg/server/errors"
+
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -47,15 +49,17 @@ func WriteJSONResponse(w http.ResponseWriter, r *http.Request, code int, respons
 }
 
 // ReadJSONBody is a generic request reader to unmarshal JSON bodies.
-// NOTE: This should have passed OpenAPI validation, so is an internal error.
+// JSON decode failures (empty body, malformed JSON, type mismatches) are
+// returned as a typed 400 client error; read failures are internal errors.
 func ReadJSONBody(r *http.Request, v any) error {
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		return fmt.Errorf("%w: unable to read request body", err)
 	}
 
-	if err := json.Unmarshal(body, v); err != nil {
-		return fmt.Errorf("%w: unable to unmarshal request body", err)
+	err = json.Unmarshal(body, v)
+	if err != nil {
+		return servererrors.OAuth2InvalidRequest("the request body is missing or malformed").WithError(err)
 	}
 
 	return nil

--- a/pkg/server/util/json_test.go
+++ b/pkg/server/util/json_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2024-2025 the Unikorn Authors.
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util_test
+
+import (
+	"bytes"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	servererrors "github.com/unikorn-cloud/core/pkg/server/errors"
+	"github.com/unikorn-cloud/core/pkg/server/util"
+)
+
+var errSimulatedRead = errors.New("simulated read error")
+
+type testPayload struct {
+	Name string `json:"name"`
+}
+
+type errReader struct{}
+
+func (errReader) Read([]byte) (int, error) { return 0, errSimulatedRead }
+
+func TestReadJSONBody(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		bodyBytes []byte
+		useErr    bool
+		expectErr bool
+		isBadReq  bool
+	}{
+		{
+			name:      "EmptyBody",
+			bodyBytes: nil,
+			expectErr: true,
+			isBadReq:  true,
+		},
+		{
+			name:      "MalformedJSON",
+			bodyBytes: []byte("{invalid"),
+			expectErr: true,
+			isBadReq:  true,
+		},
+		{
+			name:      "ReadError",
+			useErr:    true,
+			expectErr: true,
+			isBadReq:  false,
+		},
+		{
+			name:      "ValidBody",
+			bodyBytes: []byte(`{"name":"test"}`),
+			expectErr: false,
+		},
+	}
+
+	for i := range tests {
+		tc := &tests[i]
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var r *http.Request
+			if tc.useErr {
+				r = httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/", errReader{})
+			} else {
+				r = httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/", bytes.NewReader(tc.bodyBytes))
+			}
+
+			var p testPayload
+
+			err := util.ReadJSONBody(r, &p)
+
+			if tc.expectErr {
+				require.Error(t, err)
+				require.Equal(t, tc.isBadReq, servererrors.IsBadRequest(err))
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, "test", p.Name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- `ReadJSONBody` wrapped `json.Unmarshal` failures as a plain `fmt.Errorf`, which `HandleError` could not classify and fell through to a 500 response
- JSON decode failures (empty body, malformed JSON, type mismatches) are always client mistakes — they are now returned as a typed `OAuth2InvalidRequest` that `HandleError` dispatches as 400
- Body read failures (`io.ReadAll`) remain as internal errors since those indicate a server-side issue

Adds unit tests covering empty body, malformed JSON, read error (stays 500), and valid body.

Fixes INST-939. Downstream: bump this dependency in uni-region after merge.