### PR TITLE
Message queue for use in-process

### DIFF
--- a/pkg/messaging/kubernetes/README.md
+++ b/pkg/messaging/kubernetes/README.md
@@ -14,11 +14,12 @@ is essentially controller-runtime reconciliation dressed up as a queue.
 ## What Lives Here
 
 - `MessageQueue`, which owns:
-  - manager construction
-  - leader election
+  - manager construction and leader election when run standalone
   - watch registration for one object type
   - in-process fan-out to registered consumers
 - `Run()`, which starts the manager and controller.
+- `SetupWithManager()`, which registers the controller with an existing
+  controller-runtime manager.
 - `Reconcile()`, which loads the watched object and converts it into the minimal
   `messaging.Envelope` understood by consumers.
 
@@ -47,7 +48,3 @@ is essentially controller-runtime reconciliation dressed up as a queue.
   queue-like semantics.
 - Only one backend exists today. Future Kafka/NATS-style backends are intended by
   the abstraction but have not yet pressure-tested it.
-- `Reconcile()` reuses the same `q.object` storage when fetching objects. That is
-  fine in the current narrow usage, but it reinforces that this code is shaped
-  around controller-runtime flow rather than a broad general-purpose messaging
-  runtime.

--- a/pkg/messaging/kubernetes/messagequeue.go
+++ b/pkg/messaging/kubernetes/messagequeue.go
@@ -19,12 +19,14 @@ package kubernetes
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/unikorn-cloud/core/pkg/messaging"
 
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 
@@ -38,15 +40,15 @@ type MessageQueue struct {
 
 	config    *rest.Config
 	scheme    *runtime.Scheme
-	object    client.Object
+	prototype client.Object
 	consumers []messaging.Consumer
 }
 
 func New(config *rest.Config, scheme *runtime.Scheme, object client.Object) *MessageQueue {
 	return &MessageQueue{
-		config: config,
-		scheme: scheme,
-		object: object,
+		config:    config,
+		scheme:    scheme,
+		prototype: object,
 	}
 }
 
@@ -70,7 +72,7 @@ func (q *MessageQueue) Run(ctx context.Context, consumers ...messaging.Consumer)
 
 	q.Client = manager.GetClient()
 
-	if err := cr.NewControllerManagedBy(manager).For(q.object).Complete(q); err != nil {
+	if err := cr.NewControllerManagedBy(manager).For(q.prototype).Complete(q); err != nil {
 		return err
 	}
 
@@ -82,8 +84,13 @@ func (q *MessageQueue) Run(ctx context.Context, consumers ...messaging.Consumer)
 }
 
 func (q *MessageQueue) Reconcile(ctx context.Context, request cr.Request) (cr.Result, error) {
-	if err := q.Get(ctx, request.NamespacedName, q.object); err != nil {
-		if errors.IsNotFound(err) {
+	object, ok := q.prototype.DeepCopyObject().(client.Object)
+	if !ok {
+		return cr.Result{}, fmt.Errorf("%w: prototype copy could not be cast to client.Object", errors.ErrUnsupported)
+	}
+
+	if err := q.Get(ctx, request.NamespacedName, object); err != nil {
+		if apierrors.IsNotFound(err) {
 			return cr.Result{}, nil
 		}
 
@@ -91,10 +98,10 @@ func (q *MessageQueue) Reconcile(ctx context.Context, request cr.Request) (cr.Re
 	}
 
 	envelope := &messaging.Envelope{
-		ResourceID: q.object.GetName(),
+		ResourceID: object.GetName(),
 	}
 
-	if t := q.object.GetDeletionTimestamp(); t != nil {
+	if t := object.GetDeletionTimestamp(); t != nil {
 		envelope.DeletionTimestamp = &t.Time
 	}
 

--- a/pkg/messaging/kubernetes/messagequeue.go
+++ b/pkg/messaging/kubernetes/messagequeue.go
@@ -32,6 +32,7 @@ import (
 
 	cr "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	crmanager "sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 // MessageQueue implements a message queue like interface using shared informers.
@@ -52,11 +53,16 @@ func New(config *rest.Config, scheme *runtime.Scheme, object client.Object) *Mes
 	}
 }
 
+// NewForManager creates a queue that can be registered with an existing manager.
+func NewForManager(object client.Object) *MessageQueue {
+	return &MessageQueue{
+		prototype: object,
+	}
+}
+
 var _ = messaging.Queue(&MessageQueue{})
 
 func (q *MessageQueue) Run(ctx context.Context, consumers ...messaging.Consumer) error {
-	q.consumers = consumers
-
 	options := cr.Options{
 		// Explicitly adds custom resource support.
 		Scheme: q.scheme,
@@ -70,17 +76,21 @@ func (q *MessageQueue) Run(ctx context.Context, consumers ...messaging.Consumer)
 		return err
 	}
 
+	if err := q.SetupWithManager(manager, consumers...); err != nil {
+		return err
+	}
+
+	return manager.Start(ctx)
+}
+
+// SetupWithManager registers the queue's controller with an existing manager.
+func (q *MessageQueue) SetupWithManager(manager crmanager.Manager, consumers ...messaging.Consumer) error {
+	q.consumers = consumers
 	q.Client = manager.GetClient()
 
-	if err := cr.NewControllerManagedBy(manager).For(q.prototype).Complete(q); err != nil {
-		return err
-	}
-
-	if err := manager.Start(ctx); err != nil {
-		return err
-	}
-
-	return nil
+	return cr.NewControllerManagedBy(manager).
+		For(q.prototype).
+		Complete(q)
 }
 
 func (q *MessageQueue) Reconcile(ctx context.Context, request cr.Request) (cr.Result, error) {

--- a/pkg/messaging/kubernetes/messagequeue_test.go
+++ b/pkg/messaging/kubernetes/messagequeue_test.go
@@ -1,0 +1,187 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/unikorn-cloud/core/pkg/messaging/kubernetes"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+
+	cr "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var errClientFailed = errors.New("client failed")
+
+type errorClient struct {
+	client.Client
+	err error
+}
+
+func (c *errorClient) Get(context.Context, client.ObjectKey, client.Object, ...client.GetOption) error {
+	return c.err
+}
+
+func mustNewScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	return scheme
+}
+
+func newMessageQueue(t *testing.T, objects ...client.Object) *kubernetes.MessageQueue {
+	t.Helper()
+
+	scheme := mustNewScheme(t)
+
+	q := kubernetes.New(nil, scheme, &corev1.ConfigMap{})
+	q.Client = fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objects...).
+		Build()
+
+	return q
+}
+
+func TestReconcileDoesNotMutatePrototype(t *testing.T) {
+	t.Parallel()
+
+	const name = "resource"
+
+	scheme := mustNewScheme(t)
+	prototype := &corev1.ConfigMap{}
+	q := kubernetes.New(nil, scheme, prototype)
+	q.Client = fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: metav1.NamespaceDefault,
+			},
+		}).
+		Build()
+
+	if _, err := q.Reconcile(t.Context(), cr.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      name,
+			Namespace: metav1.NamespaceDefault,
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := prototype.GetName(); got != "" {
+		t.Fatalf("expected prototype name to remain empty, got %q", got)
+	}
+}
+
+func TestReconcileCanReusePrototypeForMultipleObjects(t *testing.T) {
+	t.Parallel()
+
+	const (
+		first  = "first"
+		second = "second"
+	)
+
+	scheme := mustNewScheme(t)
+	prototype := &corev1.ConfigMap{}
+	q := kubernetes.New(nil, scheme, prototype)
+	q.Client = fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      first,
+				Namespace: metav1.NamespaceDefault,
+			},
+		}, &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      second,
+				Namespace: metav1.NamespaceDefault,
+			},
+		}).
+		Build()
+
+	if _, err := q.Reconcile(t.Context(), cr.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      first,
+			Namespace: metav1.NamespaceDefault,
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := q.Reconcile(t.Context(), cr.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      second,
+			Namespace: metav1.NamespaceDefault,
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := prototype.GetName(); got != "" {
+		t.Fatalf("expected prototype name to remain empty, got %q", got)
+	}
+}
+
+func TestReconcileIgnoresMissingObject(t *testing.T) {
+	t.Parallel()
+
+	q := newMessageQueue(t)
+
+	if _, err := q.Reconcile(t.Context(), cr.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      "missing",
+			Namespace: metav1.NamespaceDefault,
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestReconcilePropagatesClientErrors(t *testing.T) {
+	t.Parallel()
+
+	const name = "resource"
+
+	scheme := mustNewScheme(t)
+	q := kubernetes.New(nil, scheme, &corev1.ConfigMap{})
+	q.Client = &errorClient{err: errClientFailed}
+
+	_, err := q.Reconcile(t.Context(), cr.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      name,
+			Namespace: metav1.NamespaceDefault,
+		},
+	})
+	if !errors.Is(err, errClientFailed) {
+		t.Fatalf("expected %v, got %v", errClientFailed, err)
+	}
+}

--- a/pkg/messaging/kubernetes/messagequeue_test.go
+++ b/pkg/messaging/kubernetes/messagequeue_test.go
@@ -20,7 +20,13 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
+	"github.com/go-logr/logr"
+	"go.uber.org/mock/gomock"
+
+	mockmanager "github.com/unikorn-cloud/core/pkg/manager/mock"
+	"github.com/unikorn-cloud/core/pkg/messaging"
 	"github.com/unikorn-cloud/core/pkg/messaging/kubernetes"
 
 	corev1 "k8s.io/api/core/v1"
@@ -31,9 +37,13 @@ import (
 	cr "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	ctrlconfig "sigs.k8s.io/controller-runtime/pkg/config"
 )
 
-var errClientFailed = errors.New("client failed")
+var (
+	errClientFailed   = errors.New("client failed")
+	errConsumerFailed = errors.New("consumer failed")
+)
 
 type errorClient struct {
 	client.Client
@@ -41,6 +51,17 @@ type errorClient struct {
 }
 
 func (c *errorClient) Get(context.Context, client.ObjectKey, client.Object, ...client.GetOption) error {
+	return c.err
+}
+
+type recordingConsumer struct {
+	envelopes []*messaging.Envelope
+	err       error
+}
+
+func (c *recordingConsumer) Consume(_ context.Context, envelope *messaging.Envelope) error {
+	c.envelopes = append(c.envelopes, envelope)
+
 	return c.err
 }
 
@@ -70,6 +91,128 @@ func newMessageQueue(t *testing.T, objects ...client.Object) *kubernetes.Message
 	return q
 }
 
+func setupQueueWithManager(t *testing.T, consumer messaging.Consumer, objects ...client.Object) *kubernetes.MessageQueue {
+	t.Helper()
+
+	scheme := mustNewScheme(t)
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objects...).
+		Build()
+	skipNameValidation := true
+
+	manager := mockmanager.NewMockManager(gomock.NewController(t))
+	manager.EXPECT().GetClient().Return(cli)
+	manager.EXPECT().GetControllerOptions().Return(ctrlconfig.Controller{
+		SkipNameValidation: &skipNameValidation,
+	}).AnyTimes()
+	manager.EXPECT().GetScheme().Return(scheme).AnyTimes()
+	manager.EXPECT().GetLogger().Return(logr.Discard()).AnyTimes()
+	manager.EXPECT().Add(gomock.Any()).Return(nil)
+	manager.EXPECT().GetCache().Return(nil)
+
+	q := kubernetes.NewForManager(&corev1.ConfigMap{})
+	if err := q.SetupWithManager(manager, consumer); err != nil {
+		t.Fatal(err)
+	}
+
+	return q
+}
+
+func TestSetupWithManagerDeliversEnvelopeFromFetchedObject(t *testing.T) {
+	t.Parallel()
+
+	const name = "resource"
+
+	consumer := &recordingConsumer{}
+	q := setupQueueWithManager(t, consumer, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: metav1.NamespaceDefault,
+		},
+	})
+
+	if _, err := q.Reconcile(t.Context(), cr.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      name,
+			Namespace: metav1.NamespaceDefault,
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(consumer.envelopes) != 1 {
+		t.Fatalf("expected 1 envelope, got %d", len(consumer.envelopes))
+	}
+
+	if got := consumer.envelopes[0].ResourceID; got != name {
+		t.Fatalf("expected resource ID %q, got %q", name, got)
+	}
+}
+
+func TestSetupWithManagerDeliversDeletionTimestampFromFetchedObject(t *testing.T) {
+	t.Parallel()
+
+	const name = "resource"
+
+	deletionTimestamp := metav1.NewTime(time.Date(2026, time.June, 1, 12, 0, 0, 0, time.UTC))
+	consumer := &recordingConsumer{}
+	q := setupQueueWithManager(t, consumer, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Namespace:         metav1.NamespaceDefault,
+			Finalizers:        []string{"test"},
+			DeletionTimestamp: &deletionTimestamp,
+		},
+	})
+
+	if _, err := q.Reconcile(t.Context(), cr.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      name,
+			Namespace: metav1.NamespaceDefault,
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(consumer.envelopes) != 1 {
+		t.Fatalf("expected 1 envelope, got %d", len(consumer.envelopes))
+	}
+
+	got := consumer.envelopes[0].DeletionTimestamp
+	if got == nil {
+		t.Fatal("expected deletion timestamp")
+	}
+
+	if !got.Equal(deletionTimestamp.Time) {
+		t.Fatalf("expected deletion timestamp %s, got %s", deletionTimestamp.Time, *got)
+	}
+}
+
+func TestReconcileReturnsConsumerError(t *testing.T) {
+	t.Parallel()
+
+	const name = "resource"
+
+	consumer := &recordingConsumer{err: errConsumerFailed}
+	q := setupQueueWithManager(t, consumer, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: metav1.NamespaceDefault,
+		},
+	})
+
+	_, err := q.Reconcile(t.Context(), cr.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      name,
+			Namespace: metav1.NamespaceDefault,
+		},
+	})
+	if !errors.Is(err, errConsumerFailed) {
+		t.Fatalf("expected %v, got %v", errConsumerFailed, err)
+	}
+}
+
 func TestReconcileDoesNotMutatePrototype(t *testing.T) {
 	t.Parallel()
 
@@ -77,7 +220,7 @@ func TestReconcileDoesNotMutatePrototype(t *testing.T) {
 
 	scheme := mustNewScheme(t)
 	prototype := &corev1.ConfigMap{}
-	q := kubernetes.New(nil, scheme, prototype)
+	q := kubernetes.NewForManager(prototype)
 	q.Client = fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithObjects(&corev1.ConfigMap{
@@ -112,7 +255,7 @@ func TestReconcileCanReusePrototypeForMultipleObjects(t *testing.T) {
 
 	scheme := mustNewScheme(t)
 	prototype := &corev1.ConfigMap{}
-	q := kubernetes.New(nil, scheme, prototype)
+	q := kubernetes.NewForManager(prototype)
 	q.Client = fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithObjects(&corev1.ConfigMap{


### PR DESCRIPTION
 - add affordances for using the kubernetes "message queue" with a manager, so it can e.g., be integrated with other controllers;
 - make sure the reconciler is concurrency-safe, in case it does get used with multiple worker threads.

From the commit message:
> New() and Run() hide the details of creating a controller-runtime
manager and controller, and starting them. This is nice and simple,
but it makes it next to impossible to use the message queue other than
in a stand-alone process.

> Since this is already in a package named Kubernetes, I don't think it
is a stretch to admit a controller-runtime integration. You might want
to do this if, for example, you want to use the events to drive a
controller.

> So: this adds the minimum you need to cleanly use a
(Kubernetes-backed) message queue with your own manager.